### PR TITLE
Update responses and requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "typescript": "^5.8.2"
   },
   "name": "@opusdns/api",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "TypeScript types for the OpusDNS OpenAPI specification",
   "main": "src/index.d.ts",
   "types": "src/index.d.ts",

--- a/scripts/helpers/generate-keys.ts
+++ b/scripts/helpers/generate-keys.ts
@@ -236,9 +236,9 @@ export const KEY_${typeNameUpper}_${keyName} = '${prop}' as keyof ${type.name};`
  *
  * @see {@link ${type.name}} - The TypeScript type definition
  */
-export const KEYS_${typeNameUpper}: readonly (keyof ${type.name})[] = [`);
+export const KEYS_${typeNameUpper} = [`);
     lines.push(...keysArray);
-    lines.push('] as const;');
+    lines.push(`] as const satisfies (keyof ${type.name})[];`);
     lines.push('');
   });
 

--- a/scripts/helpers/generate-requests.ts
+++ b/scripts/helpers/generate-requests.ts
@@ -477,7 +477,7 @@ function generateRequestsFile(groupedRequests: GroupedRequests, operationIdMap: 
  * Do not edit manually.
  */
 
-import { operations, components } from '../schema';
+import { operations } from '../schema';
 
 ${generateIndividualRequestTypesContent(groupedRequests, operationIdMap, openAPIContent)}
 `;

--- a/scripts/helpers/generate-requests.ts
+++ b/scripts/helpers/generate-requests.ts
@@ -61,7 +61,7 @@ function generatePathName(path: string): string {
 function generateRequestTypeName(path: string, method: string): string {
   const pathName = generatePathName(path);
   
-  return `${method}_${pathName}_V1_Request`;
+  return `${method}_${pathName}_Request`;
 }
 
 function extractRequestTypesFromOpenAPI(
@@ -156,7 +156,7 @@ function generateGroupedRequestTypesContent(groupedRequests: GroupedRequests): s
   for (const [pathKey, methods] of Object.entries(groupedRequests)) {
     const typeName = pathKey.replace(/_/g, '');
     content += `/**\n * Request types for ${pathKey.replace(/_/g, ' ')}\n */\n`;
-    content += `export type ${typeName}_V1_Requests = {\n`;
+          content += `export type ${typeName}_Requests = {\n`;
 
     for (const [method, requestTypes] of Object.entries(methods)) {
       content += `  ${method}: {\n`;
@@ -302,9 +302,9 @@ function generateIndividualRequestTypesContent(groupedRequests: GroupedRequests,
  *
  * @path ${actualPath}${parameterDescriptions}
  *
- * @see {@link ${typeBase}_Parameters_Query} - Query parameters type
- * @see {@link ${typeBase}_Parameters_Path} - Path parameters type
- * @see {@link ${typeBase}_RequestBody} - Request body type
+ * @see {@link ${typeBase}_Query} - Query parameters type
+ * @see {@link ${typeBase}_Path} - Path parameters type
+ * @see {@link ${typeBase}_Body} - Request body type
  */`);
       // Build parameters object
       const paramKeys: string[] = [];
@@ -365,7 +365,7 @@ function generateIndividualRequestTypesContent(groupedRequests: GroupedRequests,
       // Emit individual parameter/body types with unique, context-aware TSDoc comments
       if (paramTypes.length > 0) {
         for (const paramType of paramTypes) {
-          const typeName = `${typeBase}_Parameters_${paramType.charAt(0).toUpperCase() + paramType.slice(1)}`;
+          const typeName = `${typeBase}_${paramType.charAt(0).toUpperCase() + paramType.slice(1)}`;
           if (!emittedTypes.has(typeName)) {
             // Compose TSDoc
             let paramDoc = `/**
@@ -396,7 +396,7 @@ function generateIndividualRequestTypesContent(groupedRequests: GroupedRequests,
         }
       }
       if (requestBodyType) {
-        const typeName = `${typeBase}_RequestBody`;
+        const typeName = `${typeBase}_Body`;
         if (!emittedTypes.has(typeName)) {
           let paramDoc = `/**
  * Request body for ${method.toUpperCase()} ${actualPath}
@@ -453,21 +453,21 @@ function generateRequestsFile(groupedRequests: GroupedRequests, operationIdMap: 
  * These types ensure that request parameters match the expected API contract.
  *
  * @remarks
- * - Request types follow the pattern: \`METHOD_EndpointName_V1_Request\`
- * - Parameter types are available as: \`METHOD_EndpointName_V1_Request_Parameters_Query\`, \`METHOD_EndpointName_V1_Request_Parameters_Path\`
- * - Request body types are available as: \`METHOD_EndpointName_V1_Request_RequestBody\`
+ * - Request types follow the pattern: \`METHOD_EndpointName_Request\`
+ * - Parameter types are available as: \`METHOD_EndpointName_Request_Query\`, \`METHOD_EndpointName_Request_Path\`
+ * - Request body types are available as: \`METHOD_EndpointName_Request_Body\`
  * - All types include comprehensive parameter descriptions from the OpenAPI specification
  * - These types ensure type safety when making API requests
  *
  * @example
  * \`\`\`typescript
  * // Using request types for API calls
- * const params: GET_Domains_V1_Request_Parameters_Query = {
+ * const params: GET_Domains_Request_Query = {
  *   limit: 10,
  *   offset: 0
  * };
  * 
- * const body: POST_Domains_V1_Request_RequestBody = {
+ * const body: POST_Domains_Request_Body = {
  *   domain: 'example.com',
  *   period: 1
  * };

--- a/scripts/helpers/generate-responses.ts
+++ b/scripts/helpers/generate-responses.ts
@@ -309,7 +309,12 @@ ${seeTags}
         return individualTypeName;
       });
       
-      lines.push(`export type ${responseTypeName} = ${unionTypes.join(' | ')};`);
+      // Handle case where there are no response types (empty schema)
+      if (unionTypes.length === 0) {
+        lines.push(`export type ${responseTypeName} = unknown;`);
+      } else {
+        lines.push(`export type ${responseTypeName} = ${unionTypes.join(' | ')};`);
+      }
       lines.push(``);
       
       // Generate individual response types for each status code

--- a/scripts/helpers/generate-responses.ts
+++ b/scripts/helpers/generate-responses.ts
@@ -279,7 +279,7 @@ function generateIndividualResponseTypesContent(groupedResponses: GroupedRespons
       
       // Generate @see tags for individual response types
       const seeTags = Object.keys(methodResponses).map(responseCode => {
-        const individualTypeName = `${responseTypeName}_Response_${responseCode}`;
+        const individualTypeName = `${responseTypeName}_${responseCode}`;
         return ` * @see {@link ${individualTypeName}} - ${responseCode} response type`;
       }).join('\n');
       
@@ -305,7 +305,7 @@ ${seeTags}
       
       // Create union type of all possible response types
       const unionTypes = sortedCodes.map(responseCode => {
-        const individualTypeName = `${responseTypeName}_Response_${responseCode}`;
+        const individualTypeName = `${responseTypeName}_${responseCode}`;
         return individualTypeName;
       });
       
@@ -320,7 +320,7 @@ ${seeTags}
           isArray = true;
           schemaRef = schemaRef.slice(0, -2);
         }
-        const individualTypeName = `${responseTypeName}_Response_${responseCode}`;
+        const individualTypeName = `${responseTypeName}_${responseCode}`;
         
         lines.push(`/**
  * ${responseCode} response for ${method.toUpperCase()} ${pathName} endpoint

--- a/scripts/helpers/generate-responses.ts
+++ b/scripts/helpers/generate-responses.ts
@@ -405,7 +405,7 @@ function generateResponsesFile(groupedResponses: GroupedResponses, openAPIConten
  * Do not edit manually.
  */
 
-import { components } from '../schema';
+
 
 ${generateIndividualResponseTypesContent(groupedResponses, openAPIContent)}
 `;

--- a/scripts/helpers/generate-responses.ts
+++ b/scripts/helpers/generate-responses.ts
@@ -235,7 +235,7 @@ function generateIndividualResponseTypesContent(groupedResponses: GroupedRespons
     for (const method of sortedMethods) {
       const methodResponses = pathResponses[method];
       // Generate the main response type for this method
-      const responseTypeName = `${method}_${pathName}`;
+      const responseTypeName = `${method}_${pathName}_Response`;
       const actualPath = pathNameToPathMap[pathName] || 'unknown';
       
       // Extract parameter descriptions from the OpenAPI spec
@@ -300,17 +300,16 @@ ${seeTags}
  *
 
  */`);
-      lines.push(`export type ${responseTypeName} = {`);
-      
       // Sort response codes numerically
       const sortedCodes = Object.keys(methodResponses).sort((a, b) => parseInt(a) - parseInt(b));
       
-      for (const responseCode of sortedCodes) {
+      // Create union type of all possible response types
+      const unionTypes = sortedCodes.map(responseCode => {
         const individualTypeName = `${responseTypeName}_Response_${responseCode}`;
-        lines.push(`  ${responseCode}: ${individualTypeName}`);
-      }
+        return individualTypeName;
+      });
       
-      lines.push(`}`);
+      lines.push(`export type ${responseTypeName} = ${unionTypes.join(' | ')};`);
       lines.push(``);
       
       // Generate individual response types for each status code

--- a/src/helpers/keys.ts
+++ b/src/helpers/keys.ts
@@ -272,13 +272,13 @@ export const KEY_BODY_ISSUE_ORGANIZATION_TOKEN_V1_AUTH_TOKEN_POST_USERNAME = 'us
  *
  * @see {@link Body_issue_organization_token_v1_auth_token_post} - The TypeScript type definition
  */
-export const KEYS_BODY_ISSUE_ORGANIZATION_TOKEN_V1_AUTH_TOKEN_POST: readonly (keyof Body_issue_organization_token_v1_auth_token_post)[] = [
+export const KEYS_BODY_ISSUE_ORGANIZATION_TOKEN_V1_AUTH_TOKEN_POST = [
   KEY_BODY_ISSUE_ORGANIZATION_TOKEN_V1_AUTH_TOKEN_POST_CLIENT_ID,
   KEY_BODY_ISSUE_ORGANIZATION_TOKEN_V1_AUTH_TOKEN_POST_CLIENT_SECRET,
   KEY_BODY_ISSUE_ORGANIZATION_TOKEN_V1_AUTH_TOKEN_POST_GRANT_TYPE,
   KEY_BODY_ISSUE_ORGANIZATION_TOKEN_V1_AUTH_TOKEN_POST_PASSWORD,
   KEY_BODY_ISSUE_ORGANIZATION_TOKEN_V1_AUTH_TOKEN_POST_USERNAME,
-] as const;
+] as const satisfies (keyof Body_issue_organization_token_v1_auth_token_post)[];
 
 /**
  * Results
@@ -326,9 +326,9 @@ export const KEY_EMAIL_FORWARD_BULK_DELETE_RESULT_RESULTS = 'results' as keyof E
  *
  * @see {@link EmailForwardBulkDeleteResult} - The TypeScript type definition
  */
-export const KEYS_EMAIL_FORWARD_BULK_DELETE_RESULT: readonly (keyof EmailForwardBulkDeleteResult)[] = [
+export const KEYS_EMAIL_FORWARD_BULK_DELETE_RESULT = [
   KEY_EMAIL_FORWARD_BULK_DELETE_RESULT_RESULTS,
-] as const;
+] as const satisfies (keyof EmailForwardBulkDeleteResult)[];
 
 /**
  * Results
@@ -376,9 +376,9 @@ export const KEY_EMAIL_FORWARD_BULK_UPDATE_RESULT_RESULTS = 'results' as keyof E
  *
  * @see {@link EmailForwardBulkUpdateResult} - The TypeScript type definition
  */
-export const KEYS_EMAIL_FORWARD_BULK_UPDATE_RESULT: readonly (keyof EmailForwardBulkUpdateResult)[] = [
+export const KEYS_EMAIL_FORWARD_BULK_UPDATE_RESULT = [
   KEY_EMAIL_FORWARD_BULK_UPDATE_RESULT_RESULTS,
-] as const;
+] as const satisfies (keyof EmailForwardBulkUpdateResult)[];
 
 /**
  * Error Message
@@ -451,10 +451,10 @@ export const KEY_BULK_OPERATION_RESULT_STATUS = 'status' as keyof BulkOperationR
  *
  * @see {@link BulkOperationResult} - The TypeScript type definition
  */
-export const KEYS_BULK_OPERATION_RESULT: readonly (keyof BulkOperationResult)[] = [
+export const KEYS_BULK_OPERATION_RESULT = [
   KEY_BULK_OPERATION_RESULT_ERROR_MESSAGE,
   KEY_BULK_OPERATION_RESULT_STATUS,
-] as const;
+] as const satisfies (keyof BulkOperationResult)[];
 
 /**
  * City
@@ -811,7 +811,7 @@ export const KEY_CONTACT_CREATE_TITLE = 'title' as keyof ContactCreate;
  *
  * @see {@link ContactCreate} - The TypeScript type definition
  */
-export const KEYS_CONTACT_CREATE: readonly (keyof ContactCreate)[] = [
+export const KEYS_CONTACT_CREATE = [
   KEY_CONTACT_CREATE_CITY,
   KEY_CONTACT_CREATE_COUNTRY,
   KEY_CONTACT_CREATE_DISCLOSE,
@@ -825,7 +825,7 @@ export const KEYS_CONTACT_CREATE: readonly (keyof ContactCreate)[] = [
   KEY_CONTACT_CREATE_STATE,
   KEY_CONTACT_CREATE_STREET,
   KEY_CONTACT_CREATE_TITLE,
-] as const;
+] as const satisfies (keyof ContactCreate)[];
 
 /**
  * City
@@ -1182,7 +1182,7 @@ export const KEY_CONTACT_TITLE = 'title' as keyof Contact;
  *
  * @see {@link Contact} - The TypeScript type definition
  */
-export const KEYS_CONTACT: readonly (keyof Contact)[] = [
+export const KEYS_CONTACT = [
   KEY_CONTACT_CITY,
   KEY_CONTACT_COUNTRY,
   KEY_CONTACT_DISCLOSE,
@@ -1196,7 +1196,7 @@ export const KEYS_CONTACT: readonly (keyof Contact)[] = [
   KEY_CONTACT_STATE,
   KEY_CONTACT_STREET,
   KEY_CONTACT_TITLE,
-] as const;
+] as const satisfies (keyof Contact)[];
 
 /**
  * City
@@ -1655,7 +1655,7 @@ export const KEY_CONTACT_SCHEMA_TITLE = 'title' as keyof ContactSchema;
  *
  * @see {@link ContactSchema} - The TypeScript type definition
  */
-export const KEYS_CONTACT_SCHEMA: readonly (keyof ContactSchema)[] = [
+export const KEYS_CONTACT_SCHEMA = [
   KEY_CONTACT_SCHEMA_CITY,
   KEY_CONTACT_SCHEMA_CONTACT_ID,
   KEY_CONTACT_SCHEMA_COUNTRY,
@@ -1673,7 +1673,7 @@ export const KEYS_CONTACT_SCHEMA: readonly (keyof ContactSchema)[] = [
   KEY_CONTACT_SCHEMA_STATE,
   KEY_CONTACT_SCHEMA_STREET,
   KEY_CONTACT_SCHEMA_TITLE,
-] as const;
+] as const satisfies (keyof ContactSchema)[];
 
 /**
  * Canceled On
@@ -1925,7 +1925,7 @@ export const KEY_CONTACT_VERIFICATION_API_VERIFIED_ON = 'verified_on' as keyof C
  *
  * @see {@link ContactVerificationApi} - The TypeScript type definition
  */
-export const KEYS_CONTACT_VERIFICATION_API: readonly (keyof ContactVerificationApi)[] = [
+export const KEYS_CONTACT_VERIFICATION_API = [
   KEY_CONTACT_VERIFICATION_API_CANCELED_ON,
   KEY_CONTACT_VERIFICATION_API_CONTACT_ID,
   KEY_CONTACT_VERIFICATION_API_CONTACT_VERIFICATION_ID,
@@ -1935,7 +1935,7 @@ export const KEYS_CONTACT_VERIFICATION_API: readonly (keyof ContactVerificationA
   KEY_CONTACT_VERIFICATION_API_TYPE,
   KEY_CONTACT_VERIFICATION_API_UPDATED_ON,
   KEY_CONTACT_VERIFICATION_API_VERIFIED_ON,
-] as const;
+] as const satisfies (keyof ContactVerificationApi)[];
 
 /**
  * Canceled On
@@ -2161,7 +2161,7 @@ export const KEY_CONTACT_VERIFICATION_EMAIL_VERIFIED_ON = 'verified_on' as keyof
  *
  * @see {@link ContactVerificationEmail} - The TypeScript type definition
  */
-export const KEYS_CONTACT_VERIFICATION_EMAIL: readonly (keyof ContactVerificationEmail)[] = [
+export const KEYS_CONTACT_VERIFICATION_EMAIL = [
   KEY_CONTACT_VERIFICATION_EMAIL_CANCELED_ON,
   KEY_CONTACT_VERIFICATION_EMAIL_CONTACT_ID,
   KEY_CONTACT_VERIFICATION_EMAIL_CONTACT_VERIFICATION_ID,
@@ -2170,7 +2170,7 @@ export const KEYS_CONTACT_VERIFICATION_EMAIL: readonly (keyof ContactVerificatio
   KEY_CONTACT_VERIFICATION_EMAIL_TYPE,
   KEY_CONTACT_VERIFICATION_EMAIL_UPDATED_ON,
   KEY_CONTACT_VERIFICATION_EMAIL_VERIFIED_ON,
-] as const;
+] as const satisfies (keyof ContactVerificationEmail)[];
 
 /**
  * Canceled On
@@ -2396,7 +2396,7 @@ export const KEY_CONTACT_VERIFICATION_VERIFIED_ON = 'verified_on' as keyof Conta
  *
  * @see {@link ContactVerification} - The TypeScript type definition
  */
-export const KEYS_CONTACT_VERIFICATION: readonly (keyof ContactVerification)[] = [
+export const KEYS_CONTACT_VERIFICATION = [
   KEY_CONTACT_VERIFICATION_CANCELED_ON,
   KEY_CONTACT_VERIFICATION_CONTACT_ID,
   KEY_CONTACT_VERIFICATION_CONTACT_VERIFICATION_ID,
@@ -2405,7 +2405,7 @@ export const KEYS_CONTACT_VERIFICATION: readonly (keyof ContactVerification)[] =
   KEY_CONTACT_VERIFICATION_TYPE,
   KEY_CONTACT_VERIFICATION_UPDATED_ON,
   KEY_CONTACT_VERIFICATION_VERIFIED_ON,
-] as const;
+] as const satisfies (keyof ContactVerification)[];
 
 /**
  * date property
@@ -2452,9 +2452,9 @@ export const KEY_DELETED_EVENT_DATE = 'date' as keyof DeletedEvent;
  *
  * @see {@link DeletedEvent} - The TypeScript type definition
  */
-export const KEYS_DELETED_EVENT: readonly (keyof DeletedEvent)[] = [
+export const KEYS_DELETED_EVENT = [
   KEY_DELETED_EVENT_DATE,
-] as const;
+] as const satisfies (keyof DeletedEvent)[];
 
 /**
  * action property
@@ -2597,13 +2597,13 @@ export const KEY_DNS_CHANGE_TTL = 'ttl' as keyof DnsChange;
  *
  * @see {@link DnsChange} - The TypeScript type definition
  */
-export const KEYS_DNS_CHANGE: readonly (keyof DnsChange)[] = [
+export const KEYS_DNS_CHANGE = [
   KEY_DNS_CHANGE_ACTION,
   KEY_DNS_CHANGE_RECORD_DATA,
   KEY_DNS_CHANGE_RRSET_NAME,
   KEY_DNS_CHANGE_RRSET_TYPE,
   KEY_DNS_CHANGE_TTL,
-] as const;
+] as const satisfies (keyof DnsChange)[];
 
 /**
  * Changes
@@ -2725,12 +2725,12 @@ export const KEY_DNS_CHANGES_ZONE_NAME = 'zone_name' as keyof DnsChanges;
  *
  * @see {@link DnsChanges} - The TypeScript type definition
  */
-export const KEYS_DNS_CHANGES: readonly (keyof DnsChanges)[] = [
+export const KEYS_DNS_CHANGES = [
   KEY_DNS_CHANGES_CHANGES,
   KEY_DNS_CHANGES_CHANGESET_ID,
   KEY_DNS_CHANGES_NUM_CHANGES,
   KEY_DNS_CHANGES_ZONE_NAME,
-] as const;
+] as const satisfies (keyof DnsChanges)[];
 
 /**
  * Rdata
@@ -2778,9 +2778,9 @@ export const KEY_DNS_RECORD_CREATE_RDATA = 'rdata' as keyof DnsRecordCreate;
  *
  * @see {@link DnsRecordCreate} - The TypeScript type definition
  */
-export const KEYS_DNS_RECORD_CREATE: readonly (keyof DnsRecordCreate)[] = [
+export const KEYS_DNS_RECORD_CREATE = [
   KEY_DNS_RECORD_CREATE_RDATA,
-] as const;
+] as const satisfies (keyof DnsRecordCreate)[];
 
 /**
  * op property
@@ -2851,10 +2851,10 @@ export const KEY_DNS_RECORD_PATCH_OP_RECORD = 'record' as keyof DnsRecordPatchOp
  *
  * @see {@link DnsRecordPatchOp} - The TypeScript type definition
  */
-export const KEYS_DNS_RECORD_PATCH_OP: readonly (keyof DnsRecordPatchOp)[] = [
+export const KEYS_DNS_RECORD_PATCH_OP = [
   KEY_DNS_RECORD_PATCH_OP_OP,
   KEY_DNS_RECORD_PATCH_OP_RECORD,
-] as const;
+] as const satisfies (keyof DnsRecordPatchOp)[];
 
 /**
  * Rdata
@@ -2902,9 +2902,9 @@ export const KEY_DNS_RECORD_RDATA = 'rdata' as keyof DnsRecord;
  *
  * @see {@link DnsRecord} - The TypeScript type definition
  */
-export const KEYS_DNS_RECORD: readonly (keyof DnsRecord)[] = [
+export const KEYS_DNS_RECORD = [
   KEY_DNS_RECORD_RDATA,
-] as const;
+] as const satisfies (keyof DnsRecord)[];
 
 /**
  * Name
@@ -3026,12 +3026,12 @@ export const KEY_DNS_RRSET_CREATE_TYPE = 'type' as keyof DnsRrsetCreate;
  *
  * @see {@link DnsRrsetCreate} - The TypeScript type definition
  */
-export const KEYS_DNS_RRSET_CREATE: readonly (keyof DnsRrsetCreate)[] = [
+export const KEYS_DNS_RRSET_CREATE = [
   KEY_DNS_RRSET_CREATE_NAME,
   KEY_DNS_RRSET_CREATE_RECORDS,
   KEY_DNS_RRSET_CREATE_TTL,
   KEY_DNS_RRSET_CREATE_TYPE,
-] as const;
+] as const satisfies (keyof DnsRrsetCreate)[];
 
 /**
  * Name
@@ -3153,12 +3153,12 @@ export const KEY_DNS_RRSET_PATCH_TYPE = 'type' as keyof DnsRrsetPatch;
  *
  * @see {@link DnsRrsetPatch} - The TypeScript type definition
  */
-export const KEYS_DNS_RRSET_PATCH: readonly (keyof DnsRrsetPatch)[] = [
+export const KEYS_DNS_RRSET_PATCH = [
   KEY_DNS_RRSET_PATCH_NAME,
   KEY_DNS_RRSET_PATCH_RECORDS,
   KEY_DNS_RRSET_PATCH_TTL,
   KEY_DNS_RRSET_PATCH_TYPE,
-] as const;
+] as const satisfies (keyof DnsRrsetPatch)[];
 
 /**
  * op property
@@ -3229,10 +3229,10 @@ export const KEY_DNS_RRSET_PATCH_OP_RRSET = 'rrset' as keyof DnsRrsetPatchOp;
  *
  * @see {@link DnsRrsetPatchOp} - The TypeScript type definition
  */
-export const KEYS_DNS_RRSET_PATCH_OP: readonly (keyof DnsRrsetPatchOp)[] = [
+export const KEYS_DNS_RRSET_PATCH_OP = [
   KEY_DNS_RRSET_PATCH_OP_OP,
   KEY_DNS_RRSET_PATCH_OP_RRSET,
-] as const;
+] as const satisfies (keyof DnsRrsetPatchOp)[];
 
 /**
  * Name
@@ -3354,12 +3354,12 @@ export const KEY_DNS_RRSET_TYPE = 'type' as keyof DnsRrset;
  *
  * @see {@link DnsRrset} - The TypeScript type definition
  */
-export const KEYS_DNS_RRSET: readonly (keyof DnsRrset)[] = [
+export const KEYS_DNS_RRSET = [
   KEY_DNS_RRSET_NAME,
   KEY_DNS_RRSET_RECORDS,
   KEY_DNS_RRSET_TTL,
   KEY_DNS_RRSET_TYPE,
-] as const;
+] as const satisfies (keyof DnsRrset)[];
 
 /**
  * Name
@@ -3481,12 +3481,12 @@ export const KEY_DNS_RRSET_WITH_ONE_RECORD_PATCH_TYPE = 'type' as keyof DnsRrset
  *
  * @see {@link DnsRrsetWithOneRecordPatch} - The TypeScript type definition
  */
-export const KEYS_DNS_RRSET_WITH_ONE_RECORD_PATCH: readonly (keyof DnsRrsetWithOneRecordPatch)[] = [
+export const KEYS_DNS_RRSET_WITH_ONE_RECORD_PATCH = [
   KEY_DNS_RRSET_WITH_ONE_RECORD_PATCH_NAME,
   KEY_DNS_RRSET_WITH_ONE_RECORD_PATCH_RDATA,
   KEY_DNS_RRSET_WITH_ONE_RECORD_PATCH_TTL,
   KEY_DNS_RRSET_WITH_ONE_RECORD_PATCH_TYPE,
-] as const;
+] as const satisfies (keyof DnsRrsetWithOneRecordPatch)[];
 
 /**
  * dnssec_status property
@@ -3583,11 +3583,11 @@ export const KEY_DNS_ZONE_CREATE_RRSETS = 'rrsets' as keyof DnsZoneCreate;
  *
  * @see {@link DnsZoneCreate} - The TypeScript type definition
  */
-export const KEYS_DNS_ZONE_CREATE: readonly (keyof DnsZoneCreate)[] = [
+export const KEYS_DNS_ZONE_CREATE = [
   KEY_DNS_ZONE_CREATE_DNSSEC_STATUS,
   KEY_DNS_ZONE_CREATE_NAME,
   KEY_DNS_ZONE_CREATE_RRSETS,
-] as const;
+] as const satisfies (keyof DnsZoneCreate)[];
 
 /**
  * Ops
@@ -3635,9 +3635,9 @@ export const KEY_DNS_ZONE_RECORDS_PATCH_OPS_OPS = 'ops' as keyof DnsZoneRecordsP
  *
  * @see {@link DnsZoneRecordsPatchOps} - The TypeScript type definition
  */
-export const KEYS_DNS_ZONE_RECORDS_PATCH_OPS: readonly (keyof DnsZoneRecordsPatchOps)[] = [
+export const KEYS_DNS_ZONE_RECORDS_PATCH_OPS = [
   KEY_DNS_ZONE_RECORDS_PATCH_OPS_OPS,
-] as const;
+] as const satisfies (keyof DnsZoneRecordsPatchOps)[];
 
 /**
  * dnssec_status property
@@ -3758,12 +3758,12 @@ export const KEY_DNS_ZONE_RRSETS = 'rrsets' as keyof DnsZone;
  *
  * @see {@link DnsZone} - The TypeScript type definition
  */
-export const KEYS_DNS_ZONE: readonly (keyof DnsZone)[] = [
+export const KEYS_DNS_ZONE = [
   KEY_DNS_ZONE_DNSSEC_STATUS,
   KEY_DNS_ZONE_DOMAIN_PARTS,
   KEY_DNS_ZONE_NAME,
   KEY_DNS_ZONE_RRSETS,
-] as const;
+] as const satisfies (keyof DnsZone)[];
 
 /**
  * Rrsets
@@ -3811,9 +3811,9 @@ export const KEY_DNS_ZONE_RRSETS_CREATE_RRSETS = 'rrsets' as keyof DnsZoneRrsets
  *
  * @see {@link DnsZoneRrsetsCreate} - The TypeScript type definition
  */
-export const KEYS_DNS_ZONE_RRSETS_CREATE: readonly (keyof DnsZoneRrsetsCreate)[] = [
+export const KEYS_DNS_ZONE_RRSETS_CREATE = [
   KEY_DNS_ZONE_RRSETS_CREATE_RRSETS,
-] as const;
+] as const satisfies (keyof DnsZoneRrsetsCreate)[];
 
 /**
  * Ops
@@ -3861,9 +3861,9 @@ export const KEY_DNS_ZONE_RRSETS_PATCH_OPS_OPS = 'ops' as keyof DnsZoneRrsetsPat
  *
  * @see {@link DnsZoneRrsetsPatchOps} - The TypeScript type definition
  */
-export const KEYS_DNS_ZONE_RRSETS_PATCH_OPS: readonly (keyof DnsZoneRrsetsPatchOps)[] = [
+export const KEYS_DNS_ZONE_RRSETS_PATCH_OPS = [
   KEY_DNS_ZONE_RRSETS_PATCH_OPS_OPS,
-] as const;
+] as const satisfies (keyof DnsZoneRrsetsPatchOps)[];
 
 /**
  * Domain
@@ -3935,10 +3935,10 @@ export const KEY_DOMAIN_AVAILABILITY_STATUS = 'status' as keyof DomainAvailabili
  *
  * @see {@link DomainAvailability} - The TypeScript type definition
  */
-export const KEYS_DOMAIN_AVAILABILITY: readonly (keyof DomainAvailability)[] = [
+export const KEYS_DOMAIN_AVAILABILITY = [
   KEY_DOMAIN_AVAILABILITY_DOMAIN,
   KEY_DOMAIN_AVAILABILITY_STATUS,
-] as const;
+] as const satisfies (keyof DomainAvailability)[];
 
 /**
  * Processing Time Ms
@@ -4011,10 +4011,10 @@ export const KEY_DOMAIN_AVAILABILITY_META_TOTAL = 'total' as keyof DomainAvailab
  *
  * @see {@link DomainAvailabilityMeta} - The TypeScript type definition
  */
-export const KEYS_DOMAIN_AVAILABILITY_META: readonly (keyof DomainAvailabilityMeta)[] = [
+export const KEYS_DOMAIN_AVAILABILITY_META = [
   KEY_DOMAIN_AVAILABILITY_META_PROCESSING_TIME_MS,
   KEY_DOMAIN_AVAILABILITY_META_TOTAL,
-] as const;
+] as const satisfies (keyof DomainAvailabilityMeta)[];
 
 /**
  * Results
@@ -4062,9 +4062,9 @@ export const KEY_DOMAIN_CHECK_RESULTS = 'results' as keyof DomainCheck;
  *
  * @see {@link DomainCheck} - The TypeScript type definition
  */
-export const KEYS_DOMAIN_CHECK: readonly (keyof DomainCheck)[] = [
+export const KEYS_DOMAIN_CHECK = [
   KEY_DOMAIN_CHECK_RESULTS,
-] as const;
+] as const satisfies (keyof DomainCheck)[];
 
 /**
  * Contact Id
@@ -4138,10 +4138,10 @@ export const KEY_DOMAIN_CONTACT_CONTACT_TYPE = 'contact_type' as keyof DomainCon
  *
  * @see {@link DomainContact} - The TypeScript type definition
  */
-export const KEYS_DOMAIN_CONTACT: readonly (keyof DomainContact)[] = [
+export const KEYS_DOMAIN_CONTACT = [
   KEY_DOMAIN_CONTACT_CONTACT_ID,
   KEY_DOMAIN_CONTACT_CONTACT_TYPE,
-] as const;
+] as const satisfies (keyof DomainContact)[];
 
 /**
  * Auth Code
@@ -4315,14 +4315,14 @@ export const KEY_DOMAIN_CREATE_RENEWAL_MODE = 'renewal_mode' as keyof DomainCrea
  *
  * @see {@link DomainCreate} - The TypeScript type definition
  */
-export const KEYS_DOMAIN_CREATE: readonly (keyof DomainCreate)[] = [
+export const KEYS_DOMAIN_CREATE = [
   KEY_DOMAIN_CREATE_AUTH_CODE,
   KEY_DOMAIN_CREATE_CONTACTS,
   KEY_DOMAIN_CREATE_NAME,
   KEY_DOMAIN_CREATE_NAMESERVERS,
   KEY_DOMAIN_CREATE_PERIOD,
   KEY_DOMAIN_CREATE_RENEWAL_MODE,
-] as const;
+] as const satisfies (keyof DomainCreate)[];
 
 /**
  * algorithm property
@@ -4545,7 +4545,7 @@ export const KEY_DOMAIN_DNSSEC_DATA_CREATE_RECORD_TYPE = 'record_type' as keyof 
  *
  * @see {@link DomainDnssecDataCreate} - The TypeScript type definition
  */
-export const KEYS_DOMAIN_DNSSEC_DATA_CREATE: readonly (keyof DomainDnssecDataCreate)[] = [
+export const KEYS_DOMAIN_DNSSEC_DATA_CREATE = [
   KEY_DOMAIN_DNSSEC_DATA_CREATE_ALGORITHM,
   KEY_DOMAIN_DNSSEC_DATA_CREATE_DIGEST,
   KEY_DOMAIN_DNSSEC_DATA_CREATE_DIGEST_TYPE,
@@ -4554,7 +4554,7 @@ export const KEYS_DOMAIN_DNSSEC_DATA_CREATE: readonly (keyof DomainDnssecDataCre
   KEY_DOMAIN_DNSSEC_DATA_CREATE_PROTOCOL,
   KEY_DOMAIN_DNSSEC_DATA_CREATE_PUBLIC_KEY,
   KEY_DOMAIN_DNSSEC_DATA_CREATE_RECORD_TYPE,
-] as const;
+] as const satisfies (keyof DomainDnssecDataCreate)[];
 
 /**
  * algorithm property
@@ -4880,7 +4880,7 @@ export const KEY_DOMAIN_DNSSEC_DATA_UPDATED_ON = 'updated_on' as keyof DomainDns
  *
  * @see {@link DomainDnssecData} - The TypeScript type definition
  */
-export const KEYS_DOMAIN_DNSSEC_DATA: readonly (keyof DomainDnssecData)[] = [
+export const KEYS_DOMAIN_DNSSEC_DATA = [
   KEY_DOMAIN_DNSSEC_DATA_ALGORITHM,
   KEY_DOMAIN_DNSSEC_DATA_CREATED_ON,
   KEY_DOMAIN_DNSSEC_DATA_DIGEST,
@@ -4893,7 +4893,7 @@ export const KEYS_DOMAIN_DNSSEC_DATA: readonly (keyof DomainDnssecData)[] = [
   KEY_DOMAIN_DNSSEC_DATA_PUBLIC_KEY,
   KEY_DOMAIN_DNSSEC_DATA_RECORD_TYPE,
   KEY_DOMAIN_DNSSEC_DATA_UPDATED_ON,
-] as const;
+] as const satisfies (keyof DomainDnssecData)[];
 
 /**
  * Domain
@@ -4988,11 +4988,11 @@ export const KEY_DOMAIN_NAME_PARTS_SUFFIX = 'suffix' as keyof DomainNameParts;
  *
  * @see {@link DomainNameParts} - The TypeScript type definition
  */
-export const KEYS_DOMAIN_NAME_PARTS: readonly (keyof DomainNameParts)[] = [
+export const KEYS_DOMAIN_NAME_PARTS = [
   KEY_DOMAIN_NAME_PARTS_DOMAIN,
   KEY_DOMAIN_NAME_PARTS_SUBDOMAIN,
   KEY_DOMAIN_NAME_PARTS_SUFFIX,
-] as const;
+] as const satisfies (keyof DomainNameParts)[];
 
 /**
  * unit property
@@ -5066,10 +5066,10 @@ export const KEY_DOMAIN_PERIOD_VALUE = 'value' as keyof DomainPeriod;
  *
  * @see {@link DomainPeriod} - The TypeScript type definition
  */
-export const KEYS_DOMAIN_PERIOD: readonly (keyof DomainPeriod)[] = [
+export const KEYS_DOMAIN_PERIOD = [
   KEY_DOMAIN_PERIOD_UNIT,
   KEY_DOMAIN_PERIOD_VALUE,
-] as const;
+] as const satisfies (keyof DomainPeriod)[];
 
 /**
  * Current Expiry Date
@@ -5143,10 +5143,10 @@ export const KEY_DOMAIN_RENEW_REQUEST_PERIOD = 'period' as keyof DomainRenewRequ
  *
  * @see {@link DomainRenewRequest} - The TypeScript type definition
  */
-export const KEYS_DOMAIN_RENEW_REQUEST: readonly (keyof DomainRenewRequest)[] = [
+export const KEYS_DOMAIN_RENEW_REQUEST = [
   KEY_DOMAIN_RENEW_REQUEST_CURRENT_EXPIRY_DATE,
   KEY_DOMAIN_RENEW_REQUEST_PERIOD,
-] as const;
+] as const satisfies (keyof DomainRenewRequest)[];
 
 /**
  * Name
@@ -5246,11 +5246,11 @@ export const KEY_DOMAIN_RENEW_PERIOD_EXTENDED = 'period_extended' as keyof Domai
  *
  * @see {@link DomainRenew} - The TypeScript type definition
  */
-export const KEYS_DOMAIN_RENEW: readonly (keyof DomainRenew)[] = [
+export const KEYS_DOMAIN_RENEW = [
   KEY_DOMAIN_RENEW_NAME,
   KEY_DOMAIN_RENEW_NEW_EXPIRY_DATE,
   KEY_DOMAIN_RENEW_PERIOD_EXTENDED,
-] as const;
+] as const satisfies (keyof DomainRenew)[];
 
 /**
  * Auth Code
@@ -5784,7 +5784,7 @@ export const KEY_DOMAIN_UPDATED_ON = 'updated_on' as keyof Domain;
  *
  * @see {@link Domain} - The TypeScript type definition
  */
-export const KEYS_DOMAIN: readonly (keyof Domain)[] = [
+export const KEYS_DOMAIN = [
   KEY_DOMAIN_AUTH_CODE,
   KEY_DOMAIN_AUTH_CODE_EXPIRES_ON,
   KEY_DOMAIN_CANCELED_ON,
@@ -5805,7 +5805,7 @@ export const KEYS_DOMAIN: readonly (keyof Domain)[] = [
   KEY_DOMAIN_TLD,
   KEY_DOMAIN_TRANSFER_LOCK,
   KEY_DOMAIN_UPDATED_ON,
-] as const;
+] as const satisfies (keyof Domain)[];
 
 /**
  * Processing Time Ms
@@ -5878,10 +5878,10 @@ export const KEY_DOMAIN_SEARCH_META_TOTAL = 'total' as keyof DomainSearchMeta;
  *
  * @see {@link DomainSearchMeta} - The TypeScript type definition
  */
-export const KEYS_DOMAIN_SEARCH_META: readonly (keyof DomainSearchMeta)[] = [
+export const KEYS_DOMAIN_SEARCH_META = [
   KEY_DOMAIN_SEARCH_META_PROCESSING_TIME_MS,
   KEY_DOMAIN_SEARCH_META_TOTAL,
-] as const;
+] as const satisfies (keyof DomainSearchMeta)[];
 
 /**
  * meta property
@@ -5953,10 +5953,10 @@ export const KEY_DOMAIN_SEARCH_RESULTS = 'results' as keyof DomainSearch;
  *
  * @see {@link DomainSearch} - The TypeScript type definition
  */
-export const KEYS_DOMAIN_SEARCH: readonly (keyof DomainSearch)[] = [
+export const KEYS_DOMAIN_SEARCH = [
   KEY_DOMAIN_SEARCH_META,
   KEY_DOMAIN_SEARCH_RESULTS,
-] as const;
+] as const satisfies (keyof DomainSearch)[];
 
 /**
  * Available
@@ -6054,11 +6054,11 @@ export const KEY_DOMAIN_SEARCH_SUGGESTION_PREMIUM = 'premium' as keyof DomainSea
  *
  * @see {@link DomainSearchSuggestion} - The TypeScript type definition
  */
-export const KEYS_DOMAIN_SEARCH_SUGGESTION: readonly (keyof DomainSearchSuggestion)[] = [
+export const KEYS_DOMAIN_SEARCH_SUGGESTION = [
   KEY_DOMAIN_SEARCH_SUGGESTION_AVAILABLE,
   KEY_DOMAIN_SEARCH_SUGGESTION_DOMAIN,
   KEY_DOMAIN_SEARCH_SUGGESTION_PREMIUM,
-] as const;
+] as const satisfies (keyof DomainSearchSuggestion)[];
 
 /**
  * By Status
@@ -6184,12 +6184,12 @@ export const KEY_DOMAIN_SUMMARY_DATA_TOTAL_COUNT = 'total_count' as keyof Domain
  *
  * @see {@link DomainSummaryData} - The TypeScript type definition
  */
-export const KEYS_DOMAIN_SUMMARY_DATA: readonly (keyof DomainSummaryData)[] = [
+export const KEYS_DOMAIN_SUMMARY_DATA = [
   KEY_DOMAIN_SUMMARY_DATA_BY_STATUS,
   KEY_DOMAIN_SUMMARY_DATA_BY_TLD,
   KEY_DOMAIN_SUMMARY_DATA_EXPIRING_SOON,
   KEY_DOMAIN_SUMMARY_DATA_TOTAL_COUNT,
-] as const;
+] as const satisfies (keyof DomainSummaryData)[];
 
 /**
  * domains property
@@ -6263,10 +6263,10 @@ export const KEY_DOMAIN_SUMMARY_ORGANIZATION_ID = 'organization_id' as keyof Dom
  *
  * @see {@link DomainSummary} - The TypeScript type definition
  */
-export const KEYS_DOMAIN_SUMMARY: readonly (keyof DomainSummary)[] = [
+export const KEYS_DOMAIN_SUMMARY = [
   KEY_DOMAIN_SUMMARY_DOMAINS,
   KEY_DOMAIN_SUMMARY_ORGANIZATION_ID,
-] as const;
+] as const satisfies (keyof DomainSummary)[];
 
 /**
  * Auth Code
@@ -6391,12 +6391,12 @@ export const KEY_DOMAIN_TRANSFER_IN_RENEWAL_MODE = 'renewal_mode' as keyof Domai
  *
  * @see {@link DomainTransferIn} - The TypeScript type definition
  */
-export const KEYS_DOMAIN_TRANSFER_IN: readonly (keyof DomainTransferIn)[] = [
+export const KEYS_DOMAIN_TRANSFER_IN = [
   KEY_DOMAIN_TRANSFER_IN_AUTH_CODE,
   KEY_DOMAIN_TRANSFER_IN_CONTACTS,
   KEY_DOMAIN_TRANSFER_IN_NAME,
   KEY_DOMAIN_TRANSFER_IN_RENEWAL_MODE,
-] as const;
+] as const satisfies (keyof DomainTransferIn)[];
 
 /**
  * Auth Code
@@ -6544,13 +6544,13 @@ export const KEY_DOMAIN_UPDATE_STATUSES = 'statuses' as keyof DomainUpdate;
  *
  * @see {@link DomainUpdate} - The TypeScript type definition
  */
-export const KEYS_DOMAIN_UPDATE: readonly (keyof DomainUpdate)[] = [
+export const KEYS_DOMAIN_UPDATE = [
   KEY_DOMAIN_UPDATE_AUTH_CODE,
   KEY_DOMAIN_UPDATE_CONTACTS,
   KEY_DOMAIN_UPDATE_NAMESERVERS,
   KEY_DOMAIN_UPDATE_RENEWAL_MODE,
   KEY_DOMAIN_UPDATE_STATUSES,
-] as const;
+] as const satisfies (keyof DomainUpdate)[];
 
 /**
  * Next 30 Days
@@ -6651,11 +6651,11 @@ export const KEY_DOMAINS_EXPIRING_SOON_NEXT_90_DAYS = 'next_90_days' as keyof Do
  *
  * @see {@link DomainsExpiringSoon} - The TypeScript type definition
  */
-export const KEYS_DOMAINS_EXPIRING_SOON: readonly (keyof DomainsExpiringSoon)[] = [
+export const KEYS_DOMAINS_EXPIRING_SOON = [
   KEY_DOMAINS_EXPIRING_SOON_NEXT_30_DAYS,
   KEY_DOMAINS_EXPIRING_SOON_NEXT_60_DAYS,
   KEY_DOMAINS_EXPIRING_SOON_NEXT_90_DAYS,
-] as const;
+] as const satisfies (keyof DomainsExpiringSoon)[];
 
 /**
  * Created On
@@ -6832,14 +6832,14 @@ export const KEY_EMAIL_FORWARD_UPDATED_ON = 'updated_on' as keyof EmailForward;
  *
  * @see {@link EmailForward} - The TypeScript type definition
  */
-export const KEYS_EMAIL_FORWARD: readonly (keyof EmailForward)[] = [
+export const KEYS_EMAIL_FORWARD = [
   KEY_EMAIL_FORWARD_CREATED_ON,
   KEY_EMAIL_FORWARD_EMAIL_FORWARD_ID,
   KEY_EMAIL_FORWARD_SOURCE_ADDRESS,
   KEY_EMAIL_FORWARD_STATUS,
   KEY_EMAIL_FORWARD_TARGET_ADDRESS,
   KEY_EMAIL_FORWARD_UPDATED_ON,
-] as const;
+] as const satisfies (keyof EmailForward)[];
 
 /**
  * Email Forward Ids
@@ -6888,9 +6888,9 @@ export const KEY_EMAIL_FORWARD_BULK_DELETE_EMAIL_FORWARD_IDS = 'email_forward_id
  *
  * @see {@link EmailForwardBulkDelete} - The TypeScript type definition
  */
-export const KEYS_EMAIL_FORWARD_BULK_DELETE: readonly (keyof EmailForwardBulkDelete)[] = [
+export const KEYS_EMAIL_FORWARD_BULK_DELETE = [
   KEY_EMAIL_FORWARD_BULK_DELETE_EMAIL_FORWARD_IDS,
-] as const;
+] as const satisfies (keyof EmailForwardBulkDelete)[];
 
 /**
  * Email Forwards
@@ -6939,9 +6939,9 @@ export const KEY_EMAIL_FORWARD_BULK_UPDATE_EMAIL_FORWARDS = 'email_forwards' as 
  *
  * @see {@link EmailForwardBulkUpdate} - The TypeScript type definition
  */
-export const KEYS_EMAIL_FORWARD_BULK_UPDATE: readonly (keyof EmailForwardBulkUpdate)[] = [
+export const KEYS_EMAIL_FORWARD_BULK_UPDATE = [
   KEY_EMAIL_FORWARD_BULK_UPDATE_EMAIL_FORWARDS,
-] as const;
+] as const satisfies (keyof EmailForwardBulkUpdate)[];
 
 /**
  * Email Forward Id
@@ -7065,12 +7065,12 @@ export const KEY_EMAIL_FORWARD_BULK_UPDATE_ITEM_TARGET_ADDRESS = 'target_address
  *
  * @see {@link EmailForwardBulkUpdateItem} - The TypeScript type definition
  */
-export const KEYS_EMAIL_FORWARD_BULK_UPDATE_ITEM: readonly (keyof EmailForwardBulkUpdateItem)[] = [
+export const KEYS_EMAIL_FORWARD_BULK_UPDATE_ITEM = [
   KEY_EMAIL_FORWARD_BULK_UPDATE_ITEM_EMAIL_FORWARD_ID,
   KEY_EMAIL_FORWARD_BULK_UPDATE_ITEM_SOURCE_ADDRESS,
   KEY_EMAIL_FORWARD_BULK_UPDATE_ITEM_STATUS,
   KEY_EMAIL_FORWARD_BULK_UPDATE_ITEM_TARGET_ADDRESS,
-] as const;
+] as const satisfies (keyof EmailForwardBulkUpdateItem)[];
 
 /**
  * Source Address
@@ -7170,11 +7170,11 @@ export const KEY_EMAIL_FORWARD_CREATE_TARGET_ADDRESS = 'target_address' as keyof
  *
  * @see {@link EmailForwardCreate} - The TypeScript type definition
  */
-export const KEYS_EMAIL_FORWARD_CREATE: readonly (keyof EmailForwardCreate)[] = [
+export const KEYS_EMAIL_FORWARD_CREATE = [
   KEY_EMAIL_FORWARD_CREATE_SOURCE_ADDRESS,
   KEY_EMAIL_FORWARD_CREATE_STATUS,
   KEY_EMAIL_FORWARD_CREATE_TARGET_ADDRESS,
-] as const;
+] as const satisfies (keyof EmailForwardCreate)[];
 
 /**
  * Source Address
@@ -7272,11 +7272,11 @@ export const KEY_EMAIL_FORWARD_UPDATE_TARGET_ADDRESS = 'target_address' as keyof
  *
  * @see {@link EmailForwardUpdate} - The TypeScript type definition
  */
-export const KEYS_EMAIL_FORWARD_UPDATE: readonly (keyof EmailForwardUpdate)[] = [
+export const KEYS_EMAIL_FORWARD_UPDATE = [
   KEY_EMAIL_FORWARD_UPDATE_SOURCE_ADDRESS,
   KEY_EMAIL_FORWARD_UPDATE_STATUS,
   KEY_EMAIL_FORWARD_UPDATE_TARGET_ADDRESS,
-] as const;
+] as const satisfies (keyof EmailForwardUpdate)[];
 
 /**
  * Event Data
@@ -7448,14 +7448,14 @@ export const KEY_EVENT_RESPONSE_TYPE = 'type' as keyof EventResponse;
  *
  * @see {@link EventResponse} - The TypeScript type definition
  */
-export const KEYS_EVENT_RESPONSE: readonly (keyof EventResponse)[] = [
+export const KEYS_EVENT_RESPONSE = [
   KEY_EVENT_RESPONSE_EVENT_DATA,
   KEY_EVENT_RESPONSE_EVENT_ID,
   KEY_EVENT_RESPONSE_OBJECT_ID,
   KEY_EVENT_RESPONSE_OBJECT_TYPE,
   KEY_EVENT_RESPONSE_SUBTYPE,
   KEY_EVENT_RESPONSE_TYPE,
-] as const;
+] as const satisfies (keyof EventResponse)[];
 
 /**
  * Acknowledged On
@@ -7780,7 +7780,7 @@ export const KEY_EVENT_SCHEMA_TYPE = 'type' as keyof EventSchema;
  *
  * @see {@link EventSchema} - The TypeScript type definition
  */
-export const KEYS_EVENT_SCHEMA: readonly (keyof EventSchema)[] = [
+export const KEYS_EVENT_SCHEMA = [
   KEY_EVENT_SCHEMA_ACKNOWLEDGED_ON,
   KEY_EVENT_SCHEMA_CREATED_ON,
   KEY_EVENT_SCHEMA_EVENT_DATA,
@@ -7793,7 +7793,7 @@ export const KEYS_EVENT_SCHEMA: readonly (keyof EventSchema)[] = [
   KEY_EVENT_SCHEMA_SUBTYPE,
   KEY_EVENT_SCHEMA_TARGET,
   KEY_EVENT_SCHEMA_TYPE,
-] as const;
+] as const satisfies (keyof EventSchema)[];
 
 /**
  * errors property
@@ -7916,12 +7916,12 @@ export const KEY_H_T_T_P_VALIDATION_ERROR_TYPE = 'type' as keyof HTTPValidationE
  *
  * @see {@link HTTPValidationError} - The TypeScript type definition
  */
-export const KEYS_H_T_T_P_VALIDATION_ERROR: readonly (keyof HTTPValidationError)[] = [
+export const KEYS_H_T_T_P_VALIDATION_ERROR = [
   KEY_H_T_T_P_VALIDATION_ERROR_ERRORS,
   KEY_H_T_T_P_VALIDATION_ERROR_STATUS,
   KEY_H_T_T_P_VALIDATION_ERROR_TITLE,
   KEY_H_T_T_P_VALIDATION_ERROR_TYPE,
-] as const;
+] as const satisfies (keyof HTTPValidationError)[];
 
 /**
  * Ip Network
@@ -7995,10 +7995,10 @@ export const KEY_IP_RESTRICTION_CREATE_ORGANIZATION_ID = 'organization_id' as ke
  *
  * @see {@link IpRestrictionCreate} - The TypeScript type definition
  */
-export const KEYS_IP_RESTRICTION_CREATE: readonly (keyof IpRestrictionCreate)[] = [
+export const KEYS_IP_RESTRICTION_CREATE = [
   KEY_IP_RESTRICTION_CREATE_IP_NETWORK,
   KEY_IP_RESTRICTION_CREATE_ORGANIZATION_ID,
-] as const;
+] as const satisfies (keyof IpRestrictionCreate)[];
 
 /**
  * Created On
@@ -8146,13 +8146,13 @@ export const KEY_IP_RESTRICTION_ORGANIZATION_ID = 'organization_id' as keyof IpR
  *
  * @see {@link IpRestriction} - The TypeScript type definition
  */
-export const KEYS_IP_RESTRICTION: readonly (keyof IpRestriction)[] = [
+export const KEYS_IP_RESTRICTION = [
   KEY_IP_RESTRICTION_CREATED_ON,
   KEY_IP_RESTRICTION_IP_NETWORK,
   KEY_IP_RESTRICTION_IP_RESTRICTION_ID,
   KEY_IP_RESTRICTION_LAST_USED_ON,
   KEY_IP_RESTRICTION_ORGANIZATION_ID,
-] as const;
+] as const satisfies (keyof IpRestriction)[];
 
 /**
  * Ip Network
@@ -8225,10 +8225,10 @@ export const KEY_IP_RESTRICTION_UPDATE_LAST_USED_ON = 'last_used_on' as keyof Ip
  *
  * @see {@link IpRestrictionUpdate} - The TypeScript type definition
  */
-export const KEYS_IP_RESTRICTION_UPDATE: readonly (keyof IpRestrictionUpdate)[] = [
+export const KEYS_IP_RESTRICTION_UPDATE = [
   KEY_IP_RESTRICTION_UPDATE_IP_NETWORK,
   KEY_IP_RESTRICTION_UPDATE_LAST_USED_ON,
-] as const;
+] as const satisfies (keyof IpRestrictionUpdate)[];
 
 /**
  * Hostname
@@ -8303,10 +8303,10 @@ export const KEY_NAMESERVER_IP_ADDRESSES = 'ip_addresses' as keyof Nameserver;
  *
  * @see {@link Nameserver} - The TypeScript type definition
  */
-export const KEYS_NAMESERVER: readonly (keyof Nameserver)[] = [
+export const KEYS_NAMESERVER = [
   KEY_NAMESERVER_HOSTNAME,
   KEY_NAMESERVER_IP_ADDRESSES,
-] as const;
+] as const satisfies (keyof Nameserver)[];
 
 /**
  * Author
@@ -8588,7 +8588,7 @@ export const KEY_NOTIFICATION_UPDATED_ON = 'updated_on' as keyof Notification;
  *
  * @see {@link Notification} - The TypeScript type definition
  */
-export const KEYS_NOTIFICATION: readonly (keyof Notification)[] = [
+export const KEYS_NOTIFICATION = [
   KEY_NOTIFICATION_AUTHOR,
   KEY_NOTIFICATION_CREATED_ON,
   KEY_NOTIFICATION_MESSAGE,
@@ -8599,7 +8599,7 @@ export const KEYS_NOTIFICATION: readonly (keyof Notification)[] = [
   KEY_NOTIFICATION_TARGET,
   KEY_NOTIFICATION_TYPE,
   KEY_NOTIFICATION_UPDATED_ON,
-] as const;
+] as const satisfies (keyof Notification)[];
 
 /**
  * Author
@@ -8804,7 +8804,7 @@ export const KEY_NOTIFICATION_CREATE_TYPE = 'type' as keyof NotificationCreate;
  *
  * @see {@link NotificationCreate} - The TypeScript type definition
  */
-export const KEYS_NOTIFICATION_CREATE: readonly (keyof NotificationCreate)[] = [
+export const KEYS_NOTIFICATION_CREATE = [
   KEY_NOTIFICATION_CREATE_AUTHOR,
   KEY_NOTIFICATION_CREATE_MESSAGE,
   KEY_NOTIFICATION_CREATE_PUBLISH_DATE,
@@ -8812,7 +8812,7 @@ export const KEYS_NOTIFICATION_CREATE: readonly (keyof NotificationCreate)[] = [
   KEY_NOTIFICATION_CREATE_SUBJECT,
   KEY_NOTIFICATION_CREATE_TARGET,
   KEY_NOTIFICATION_CREATE_TYPE,
-] as const;
+] as const satisfies (keyof NotificationCreate)[];
 
 /**
  * Author
@@ -9042,7 +9042,7 @@ export const KEY_NOTIFICATION_SUMMARY_TYPE = 'type' as keyof NotificationSummary
  *
  * @see {@link NotificationSummary} - The TypeScript type definition
  */
-export const KEYS_NOTIFICATION_SUMMARY: readonly (keyof NotificationSummary)[] = [
+export const KEYS_NOTIFICATION_SUMMARY = [
   KEY_NOTIFICATION_SUMMARY_AUTHOR,
   KEY_NOTIFICATION_SUMMARY_MESSAGE,
   KEY_NOTIFICATION_SUMMARY_NOTIFICATION_ID,
@@ -9051,7 +9051,7 @@ export const KEYS_NOTIFICATION_SUMMARY: readonly (keyof NotificationSummary)[] =
   KEY_NOTIFICATION_SUMMARY_SUBJECT,
   KEY_NOTIFICATION_SUMMARY_TARGET,
   KEY_NOTIFICATION_SUMMARY_TYPE,
-] as const;
+] as const satisfies (keyof NotificationSummary)[];
 
 /**
  * Author
@@ -9256,7 +9256,7 @@ export const KEY_NOTIFICATION_UPDATE_TYPE = 'type' as keyof NotificationUpdate;
  *
  * @see {@link NotificationUpdate} - The TypeScript type definition
  */
-export const KEYS_NOTIFICATION_UPDATE: readonly (keyof NotificationUpdate)[] = [
+export const KEYS_NOTIFICATION_UPDATE = [
   KEY_NOTIFICATION_UPDATE_AUTHOR,
   KEY_NOTIFICATION_UPDATE_MESSAGE,
   KEY_NOTIFICATION_UPDATE_PUBLISH_DATE,
@@ -9264,7 +9264,7 @@ export const KEYS_NOTIFICATION_UPDATE: readonly (keyof NotificationUpdate)[] = [
   KEY_NOTIFICATION_UPDATE_SUBJECT,
   KEY_NOTIFICATION_UPDATE_TARGET,
   KEY_NOTIFICATION_UPDATE_TYPE,
-] as const;
+] as const satisfies (keyof NotificationUpdate)[];
 
 /**
  * Address 1
@@ -9790,7 +9790,7 @@ export const KEY_ORGANIZATION_USERS = 'users' as keyof Organization;
  *
  * @see {@link Organization} - The TypeScript type definition
  */
-export const KEYS_ORGANIZATION: readonly (keyof Organization)[] = [
+export const KEYS_ORGANIZATION = [
   KEY_ORGANIZATION_ADDRESS_1,
   KEY_ORGANIZATION_ADDRESS_2,
   KEY_ORGANIZATION_ATTRIBUTES,
@@ -9811,7 +9811,7 @@ export const KEYS_ORGANIZATION: readonly (keyof Organization)[] = [
   KEY_ORGANIZATION_TAX_ID_TYPE,
   KEY_ORGANIZATION_TAX_RATE,
   KEY_ORGANIZATION_USERS,
-] as const;
+] as const satisfies (keyof Organization)[];
 
 /**
  * Created On
@@ -10014,7 +10014,7 @@ export const KEY_ORGANIZATION_ATTRIBUTE_VALUE = 'value' as keyof OrganizationAtt
  *
  * @see {@link OrganizationAttribute} - The TypeScript type definition
  */
-export const KEYS_ORGANIZATION_ATTRIBUTE: readonly (keyof OrganizationAttribute)[] = [
+export const KEYS_ORGANIZATION_ATTRIBUTE = [
   KEY_ORGANIZATION_ATTRIBUTE_CREATED_ON,
   KEY_ORGANIZATION_ATTRIBUTE_KEY,
   KEY_ORGANIZATION_ATTRIBUTE_ORGANIZATION_ATTRIBUTE_ID,
@@ -10022,7 +10022,7 @@ export const KEYS_ORGANIZATION_ATTRIBUTE: readonly (keyof OrganizationAttribute)
   KEY_ORGANIZATION_ATTRIBUTE_PROTECTED,
   KEY_ORGANIZATION_ATTRIBUTE_UPDATED_ON,
   KEY_ORGANIZATION_ATTRIBUTE_VALUE,
-] as const;
+] as const satisfies (keyof OrganizationAttribute)[];
 
 /**
  * Key
@@ -10148,12 +10148,12 @@ export const KEY_ORGANIZATION_ATTRIBUTE_CREATE_VALUE = 'value' as keyof Organiza
  *
  * @see {@link OrganizationAttributeCreate} - The TypeScript type definition
  */
-export const KEYS_ORGANIZATION_ATTRIBUTE_CREATE: readonly (keyof OrganizationAttributeCreate)[] = [
+export const KEYS_ORGANIZATION_ATTRIBUTE_CREATE = [
   KEY_ORGANIZATION_ATTRIBUTE_CREATE_KEY,
   KEY_ORGANIZATION_ATTRIBUTE_CREATE_PRIVATE,
   KEY_ORGANIZATION_ATTRIBUTE_CREATE_PROTECTED,
   KEY_ORGANIZATION_ATTRIBUTE_CREATE_VALUE,
-] as const;
+] as const satisfies (keyof OrganizationAttributeCreate)[];
 
 /**
  * Created On
@@ -10330,14 +10330,14 @@ export const KEY_ORGANIZATION_ATTRIBUTE2_VALUE = 'value' as keyof OrganizationAt
  *
  * @see {@link OrganizationAttribute2} - The TypeScript type definition
  */
-export const KEYS_ORGANIZATION_ATTRIBUTE2: readonly (keyof OrganizationAttribute2)[] = [
+export const KEYS_ORGANIZATION_ATTRIBUTE2 = [
   KEY_ORGANIZATION_ATTRIBUTE2_CREATED_ON,
   KEY_ORGANIZATION_ATTRIBUTE2_KEY,
   KEY_ORGANIZATION_ATTRIBUTE2_ORGANIZATION_ATTRIBUTE_ID,
   KEY_ORGANIZATION_ATTRIBUTE2_PROTECTED,
   KEY_ORGANIZATION_ATTRIBUTE2_UPDATED_ON,
   KEY_ORGANIZATION_ATTRIBUTE2_VALUE,
-] as const;
+] as const satisfies (keyof OrganizationAttribute2)[];
 
 /**
  * Key
@@ -10463,12 +10463,12 @@ export const KEY_ORGANIZATION_ATTRIBUTE_UPDATE_VALUE = 'value' as keyof Organiza
  *
  * @see {@link OrganizationAttributeUpdate} - The TypeScript type definition
  */
-export const KEYS_ORGANIZATION_ATTRIBUTE_UPDATE: readonly (keyof OrganizationAttributeUpdate)[] = [
+export const KEYS_ORGANIZATION_ATTRIBUTE_UPDATE = [
   KEY_ORGANIZATION_ATTRIBUTE_UPDATE_KEY,
   KEY_ORGANIZATION_ATTRIBUTE_UPDATE_PRIVATE,
   KEY_ORGANIZATION_ATTRIBUTE_UPDATE_PROTECTED,
   KEY_ORGANIZATION_ATTRIBUTE_UPDATE_VALUE,
-] as const;
+] as const satisfies (keyof OrganizationAttributeUpdate)[];
 
 /**
  * Address 1
@@ -10894,7 +10894,7 @@ export const KEY_ORGANIZATION_CREATE_USERS = 'users' as keyof OrganizationCreate
  *
  * @see {@link OrganizationCreate} - The TypeScript type definition
  */
-export const KEYS_ORGANIZATION_CREATE: readonly (keyof OrganizationCreate)[] = [
+export const KEYS_ORGANIZATION_CREATE = [
   KEY_ORGANIZATION_CREATE_ADDRESS_1,
   KEY_ORGANIZATION_CREATE_ADDRESS_2,
   KEY_ORGANIZATION_CREATE_ATTRIBUTES,
@@ -10911,7 +10911,7 @@ export const KEYS_ORGANIZATION_CREATE: readonly (keyof OrganizationCreate)[] = [
   KEY_ORGANIZATION_CREATE_TAX_ID_TYPE,
   KEY_ORGANIZATION_CREATE_TAX_RATE,
   KEY_ORGANIZATION_CREATE_USERS,
-] as const;
+] as const satisfies (keyof OrganizationCreate)[];
 
 /**
  * Api Key Description
@@ -11136,7 +11136,7 @@ export const KEY_ORGANIZATION_CREDENTIAL_STATUS = 'status' as keyof Organization
  *
  * @see {@link OrganizationCredential} - The TypeScript type definition
  */
-export const KEYS_ORGANIZATION_CREDENTIAL: readonly (keyof OrganizationCredential)[] = [
+export const KEYS_ORGANIZATION_CREDENTIAL = [
   KEY_ORGANIZATION_CREDENTIAL_API_KEY_DESCRIPTION,
   KEY_ORGANIZATION_CREDENTIAL_API_KEY_ID,
   KEY_ORGANIZATION_CREDENTIAL_API_KEY_NAME,
@@ -11145,7 +11145,7 @@ export const KEYS_ORGANIZATION_CREDENTIAL: readonly (keyof OrganizationCredentia
   KEY_ORGANIZATION_CREDENTIAL_LAST_USED_ON,
   KEY_ORGANIZATION_CREDENTIAL_ORGANIZATION_ID,
   KEY_ORGANIZATION_CREDENTIAL_STATUS,
-] as const;
+] as const satisfies (keyof OrganizationCredential)[];
 
 /**
  * Api Key
@@ -11395,7 +11395,7 @@ export const KEY_ORGANIZATION_CREDENTIAL_CREATED_STATUS = 'status' as keyof Orga
  *
  * @see {@link OrganizationCredentialCreated} - The TypeScript type definition
  */
-export const KEYS_ORGANIZATION_CREDENTIAL_CREATED: readonly (keyof OrganizationCredentialCreated)[] = [
+export const KEYS_ORGANIZATION_CREDENTIAL_CREATED = [
   KEY_ORGANIZATION_CREDENTIAL_CREATED_API_KEY,
   KEY_ORGANIZATION_CREDENTIAL_CREATED_API_KEY_DESCRIPTION,
   KEY_ORGANIZATION_CREDENTIAL_CREATED_API_KEY_NAME,
@@ -11405,7 +11405,7 @@ export const KEYS_ORGANIZATION_CREDENTIAL_CREATED: readonly (keyof OrganizationC
   KEY_ORGANIZATION_CREDENTIAL_CREATED_DELETED_ON,
   KEY_ORGANIZATION_CREDENTIAL_CREATED_LAST_USED_ON,
   KEY_ORGANIZATION_CREDENTIAL_CREATED_STATUS,
-] as const;
+] as const satisfies (keyof OrganizationCredentialCreated)[];
 
 /**
  * Api Key Description
@@ -11503,11 +11503,11 @@ export const KEY_ORGANIZATION_CREDENTIAL_EXTRA_EXPIRES_AT = 'expires_at' as keyo
  *
  * @see {@link OrganizationCredentialExtra} - The TypeScript type definition
  */
-export const KEYS_ORGANIZATION_CREDENTIAL_EXTRA: readonly (keyof OrganizationCredentialExtra)[] = [
+export const KEYS_ORGANIZATION_CREDENTIAL_EXTRA = [
   KEY_ORGANIZATION_CREDENTIAL_EXTRA_API_KEY_DESCRIPTION,
   KEY_ORGANIZATION_CREDENTIAL_EXTRA_API_KEY_NAME,
   KEY_ORGANIZATION_CREDENTIAL_EXTRA_EXPIRES_AT,
-] as const;
+] as const satisfies (keyof OrganizationCredentialExtra)[];
 
 /**
  * Access Token
@@ -11605,11 +11605,11 @@ export const KEY_ORGANIZATION_TOKEN_TOKEN_TYPE = 'token_type' as keyof Organizat
  *
  * @see {@link OrganizationToken} - The TypeScript type definition
  */
-export const KEYS_ORGANIZATION_TOKEN: readonly (keyof OrganizationToken)[] = [
+export const KEYS_ORGANIZATION_TOKEN = [
   KEY_ORGANIZATION_TOKEN_ACCESS_TOKEN,
   KEY_ORGANIZATION_TOKEN_EXPIRES_IN,
   KEY_ORGANIZATION_TOKEN_TOKEN_TYPE,
-] as const;
+] as const satisfies (keyof OrganizationToken)[];
 
 /**
  * Address 1
@@ -11931,7 +11931,7 @@ export const KEY_ORGANIZATION_UPDATE_TAX_RATE = 'tax_rate' as keyof Organization
  *
  * @see {@link OrganizationUpdate} - The TypeScript type definition
  */
-export const KEYS_ORGANIZATION_UPDATE: readonly (keyof OrganizationUpdate)[] = [
+export const KEYS_ORGANIZATION_UPDATE = [
   KEY_ORGANIZATION_UPDATE_ADDRESS_1,
   KEY_ORGANIZATION_UPDATE_ADDRESS_2,
   KEY_ORGANIZATION_UPDATE_BUSINESS_NUMBER,
@@ -11944,7 +11944,7 @@ export const KEYS_ORGANIZATION_UPDATE: readonly (keyof OrganizationUpdate)[] = [
   KEY_ORGANIZATION_UPDATE_TAX_ID,
   KEY_ORGANIZATION_UPDATE_TAX_ID_TYPE,
   KEY_ORGANIZATION_UPDATE_TAX_RATE,
-] as const;
+] as const satisfies (keyof OrganizationUpdate)[];
 
 /**
  * Address 1
@@ -12494,7 +12494,7 @@ export const KEY_ORGANIZATION_WITH_PLAN_USERS = 'users' as keyof OrganizationWit
  *
  * @see {@link OrganizationWithPlan} - The TypeScript type definition
  */
-export const KEYS_ORGANIZATION_WITH_PLAN: readonly (keyof OrganizationWithPlan)[] = [
+export const KEYS_ORGANIZATION_WITH_PLAN = [
   KEY_ORGANIZATION_WITH_PLAN_ADDRESS_1,
   KEY_ORGANIZATION_WITH_PLAN_ADDRESS_2,
   KEY_ORGANIZATION_WITH_PLAN_ATTRIBUTES,
@@ -12516,7 +12516,7 @@ export const KEYS_ORGANIZATION_WITH_PLAN: readonly (keyof OrganizationWithPlan)[
   KEY_ORGANIZATION_WITH_PLAN_TAX_ID_TYPE,
   KEY_ORGANIZATION_WITH_PLAN_TAX_RATE,
   KEY_ORGANIZATION_WITH_PLAN_USERS,
-] as const;
+] as const satisfies (keyof OrganizationWithPlan)[];
 
 /**
  * Current Page
@@ -12689,14 +12689,14 @@ export const KEY_PAGINATION_METADATA_TOTAL_PAGES = 'total_pages' as keyof Pagina
  *
  * @see {@link PaginationMetadata} - The TypeScript type definition
  */
-export const KEYS_PAGINATION_METADATA: readonly (keyof PaginationMetadata)[] = [
+export const KEYS_PAGINATION_METADATA = [
   KEY_PAGINATION_METADATA_CURRENT_PAGE,
   KEY_PAGINATION_METADATA_HAS_NEXT_PAGE,
   KEY_PAGINATION_METADATA_HAS_PREVIOUS_PAGE,
   KEY_PAGINATION_METADATA_PAGE_SIZE,
   KEY_PAGINATION_METADATA_TOTAL_ITEMS,
   KEY_PAGINATION_METADATA_TOTAL_PAGES,
-] as const;
+] as const satisfies (keyof PaginationMetadata)[];
 
 /**
  * Permissions
@@ -12744,9 +12744,9 @@ export const KEY_PERMISSION_SET_PERMISSIONS = 'permissions' as keyof PermissionS
  *
  * @see {@link PermissionSet} - The TypeScript type definition
  */
-export const KEYS_PERMISSION_SET: readonly (keyof PermissionSet)[] = [
+export const KEYS_PERMISSION_SET = [
   KEY_PERMISSION_SET_PERMISSIONS,
-] as const;
+] as const satisfies (keyof PermissionSet)[];
 
 /**
  * plan property
@@ -12793,9 +12793,9 @@ export const KEY_PLAN_UPDATE_PLAN = 'plan' as keyof PlanUpdate;
  *
  * @see {@link PlanUpdate} - The TypeScript type definition
  */
-export const KEYS_PLAN_UPDATE: readonly (keyof PlanUpdate)[] = [
+export const KEYS_PLAN_UPDATE = [
   KEY_PLAN_UPDATE_PLAN,
-] as const;
+] as const satisfies (keyof PlanUpdate)[];
 
 /**
  * Problem detail
@@ -12917,12 +12917,12 @@ export const KEY_PROBLEM_TYPE = 'type' as keyof Problem;
  *
  * @see {@link Problem} - The TypeScript type definition
  */
-export const KEYS_PROBLEM: readonly (keyof Problem)[] = [
+export const KEYS_PROBLEM = [
   KEY_PROBLEM_DETAIL,
   KEY_PROBLEM_STATUS,
   KEY_PROBLEM_TITLE,
   KEY_PROBLEM_TYPE,
-] as const;
+] as const satisfies (keyof Problem)[];
 
 /**
  * Relations
@@ -12970,9 +12970,9 @@ export const KEY_RELATION_SET_RELATIONS = 'relations' as keyof RelationSet;
  *
  * @see {@link RelationSet} - The TypeScript type definition
  */
-export const KEYS_RELATION_SET: readonly (keyof RelationSet)[] = [
+export const KEYS_RELATION_SET = [
   KEY_RELATION_SET_RELATIONS,
-] as const;
+] as const satisfies (keyof RelationSet)[];
 
 /**
  * organization property
@@ -13070,11 +13070,11 @@ export const KEY_SIGNUP_CREATE_USER = 'user' as keyof SignupCreate;
  *
  * @see {@link SignupCreate} - The TypeScript type definition
  */
-export const KEYS_SIGNUP_CREATE: readonly (keyof SignupCreate)[] = [
+export const KEYS_SIGNUP_CREATE = [
   KEY_SIGNUP_CREATE_ORGANIZATION,
   KEY_SIGNUP_CREATE_TERMS_OF_SERVICE,
   KEY_SIGNUP_CREATE_USER,
-] as const;
+] as const satisfies (keyof SignupCreate)[];
 
 /**
  * Add
@@ -13145,10 +13145,10 @@ export const KEY_SPICE_DB_RELATIONSHIP_UPDATE_REMOVE = 'remove' as keyof SpiceDb
  *
  * @see {@link SpiceDbRelationshipUpdate} - The TypeScript type definition
  */
-export const KEYS_SPICE_DB_RELATIONSHIP_UPDATE: readonly (keyof SpiceDbRelationshipUpdate)[] = [
+export const KEYS_SPICE_DB_RELATIONSHIP_UPDATE = [
   KEY_SPICE_DB_RELATIONSHIP_UPDATE_ADD,
   KEY_SPICE_DB_RELATIONSHIP_UPDATE_REMOVE,
-] as const;
+] as const satisfies (keyof SpiceDbRelationshipUpdate)[];
 
 /**
  * Accepted
@@ -13196,9 +13196,9 @@ export const KEY_TERMS_OF_SERVICE_ACCEPT_ACCEPTED = 'accepted' as keyof TermsOfS
  *
  * @see {@link TermsOfServiceAccept} - The TypeScript type definition
  */
-export const KEYS_TERMS_OF_SERVICE_ACCEPT: readonly (keyof TermsOfServiceAccept)[] = [
+export const KEYS_TERMS_OF_SERVICE_ACCEPT = [
   KEY_TERMS_OF_SERVICE_ACCEPT_ACCEPTED,
-] as const;
+] as const satisfies (keyof TermsOfServiceAccept)[];
 
 /**
  * Current Registrar
@@ -13344,13 +13344,13 @@ export const KEY_TRANSFER_EVENT_REQUESTING_REGISTRAR = 'requesting_registrar' as
  *
  * @see {@link TransferEvent} - The TypeScript type definition
  */
-export const KEYS_TRANSFER_EVENT: readonly (keyof TransferEvent)[] = [
+export const KEYS_TRANSFER_EVENT = [
   KEY_TRANSFER_EVENT_CURRENT_REGISTRAR,
   KEY_TRANSFER_EVENT_EXECUTION_DATE,
   KEY_TRANSFER_EVENT_EXPIRATION_DATE,
   KEY_TRANSFER_EVENT_MESSAGE,
   KEY_TRANSFER_EVENT_REQUESTING_REGISTRAR,
-] as const;
+] as const satisfies (keyof TransferEvent)[];
 
 /**
  * Created On
@@ -13679,7 +13679,7 @@ export const KEY_USER_USERNAME = 'username' as keyof User;
  *
  * @see {@link User} - The TypeScript type definition
  */
-export const KEYS_USER: readonly (keyof User)[] = [
+export const KEYS_USER = [
   KEY_USER_CREATED_ON,
   KEY_USER_DELETED_ON,
   KEY_USER_EMAIL,
@@ -13692,7 +13692,7 @@ export const KEYS_USER: readonly (keyof User)[] = [
   KEY_USER_UPDATED_ON,
   KEY_USER_USER_ID,
   KEY_USER_USERNAME,
-] as const;
+] as const satisfies (keyof User)[];
 
 /**
  * Key
@@ -13766,10 +13766,10 @@ export const KEY_USER_ATTRIBUTE_UPDATE_VALUE = 'value' as keyof UserAttributeUpd
  *
  * @see {@link UserAttributeUpdate} - The TypeScript type definition
  */
-export const KEYS_USER_ATTRIBUTE_UPDATE: readonly (keyof UserAttributeUpdate)[] = [
+export const KEYS_USER_ATTRIBUTE_UPDATE = [
   KEY_USER_ATTRIBUTE_UPDATE_KEY,
   KEY_USER_ATTRIBUTE_UPDATE_VALUE,
-] as const;
+] as const satisfies (keyof UserAttributeUpdate)[];
 
 /**
  * Email
@@ -13972,7 +13972,7 @@ export const KEY_USER_CREATE_USERNAME = 'username' as keyof UserCreate;
  *
  * @see {@link UserCreate} - The TypeScript type definition
  */
-export const KEYS_USER_CREATE: readonly (keyof UserCreate)[] = [
+export const KEYS_USER_CREATE = [
   KEY_USER_CREATE_EMAIL,
   KEY_USER_CREATE_FIRST_NAME,
   KEY_USER_CREATE_LAST_NAME,
@@ -13980,7 +13980,7 @@ export const KEYS_USER_CREATE: readonly (keyof UserCreate)[] = [
   KEY_USER_CREATE_PASSWORD,
   KEY_USER_CREATE_PHONE,
   KEY_USER_CREATE_USERNAME,
-] as const;
+] as const satisfies (keyof UserCreate)[];
 
 /**
  * Created On
@@ -14180,7 +14180,7 @@ export const KEY_USER_NOTIFICATION_USER_NOTIFICATION_ID = 'user_notification_id'
  *
  * @see {@link UserNotification} - The TypeScript type definition
  */
-export const KEYS_USER_NOTIFICATION: readonly (keyof UserNotification)[] = [
+export const KEYS_USER_NOTIFICATION = [
   KEY_USER_NOTIFICATION_CREATED_ON,
   KEY_USER_NOTIFICATION_NOTIFICATION,
   KEY_USER_NOTIFICATION_NOTIFICATION_ID,
@@ -14188,7 +14188,7 @@ export const KEYS_USER_NOTIFICATION: readonly (keyof UserNotification)[] = [
   KEY_USER_NOTIFICATION_UPDATED_ON,
   KEY_USER_NOTIFICATION_USER_ID,
   KEY_USER_NOTIFICATION_USER_NOTIFICATION_ID,
-] as const;
+] as const satisfies (keyof UserNotification)[];
 
 /**
  * notification property
@@ -14285,11 +14285,11 @@ export const KEY_USER_NOTIFICATION_SUMMARY_USER_NOTIFICATION_ID = 'user_notifica
  *
  * @see {@link UserNotificationSummary} - The TypeScript type definition
  */
-export const KEYS_USER_NOTIFICATION_SUMMARY: readonly (keyof UserNotificationSummary)[] = [
+export const KEYS_USER_NOTIFICATION_SUMMARY = [
   KEY_USER_NOTIFICATION_SUMMARY_NOTIFICATION,
   KEY_USER_NOTIFICATION_SUMMARY_STATUS,
   KEY_USER_NOTIFICATION_SUMMARY_USER_NOTIFICATION_ID,
-] as const;
+] as const satisfies (keyof UserNotificationSummary)[];
 
 /**
  * Access Token
@@ -14437,13 +14437,13 @@ export const KEY_USER_TOKEN_TOKEN_TYPE = 'token_type' as keyof UserToken;
  *
  * @see {@link UserToken} - The TypeScript type definition
  */
-export const KEYS_USER_TOKEN: readonly (keyof UserToken)[] = [
+export const KEYS_USER_TOKEN = [
   KEY_USER_TOKEN_ACCESS_TOKEN,
   KEY_USER_TOKEN_EXPIRES_IN,
   KEY_USER_TOKEN_REFRESH_EXPIRES_IN,
   KEY_USER_TOKEN_REFRESH_TOKEN,
   KEY_USER_TOKEN_TOKEN_TYPE,
-] as const;
+] as const satisfies (keyof UserToken)[];
 
 /**
  * Email
@@ -14641,7 +14641,7 @@ export const KEY_USER_UPDATE_USERNAME = 'username' as keyof UserUpdate;
  *
  * @see {@link UserUpdate} - The TypeScript type definition
  */
-export const KEYS_USER_UPDATE: readonly (keyof UserUpdate)[] = [
+export const KEYS_USER_UPDATE = [
   KEY_USER_UPDATE_EMAIL,
   KEY_USER_UPDATE_FIRST_NAME,
   KEY_USER_UPDATE_LAST_NAME,
@@ -14649,7 +14649,7 @@ export const KEYS_USER_UPDATE: readonly (keyof UserUpdate)[] = [
   KEY_USER_UPDATE_PHONE,
   KEY_USER_UPDATE_USER_ATTRIBUTES,
   KEY_USER_UPDATE_USERNAME,
-] as const;
+] as const satisfies (keyof UserUpdate)[];
 
 /**
  * Created On
@@ -15004,7 +15004,7 @@ export const KEY_USER_WITH_ATTRIBUTES_USERNAME = 'username' as keyof UserWithAtt
  *
  * @see {@link UserWithAttributes} - The TypeScript type definition
  */
-export const KEYS_USER_WITH_ATTRIBUTES: readonly (keyof UserWithAttributes)[] = [
+export const KEYS_USER_WITH_ATTRIBUTES = [
   KEY_USER_WITH_ATTRIBUTES_CREATED_ON,
   KEY_USER_WITH_ATTRIBUTES_DELETED_ON,
   KEY_USER_WITH_ATTRIBUTES_EMAIL,
@@ -15018,7 +15018,7 @@ export const KEYS_USER_WITH_ATTRIBUTES: readonly (keyof UserWithAttributes)[] = 
   KEY_USER_WITH_ATTRIBUTES_USER_ATTRIBUTES,
   KEY_USER_WITH_ATTRIBUTES_USER_ID,
   KEY_USER_WITH_ATTRIBUTES_USERNAME,
-] as const;
+] as const satisfies (keyof UserWithAttributes)[];
 
 /**
  * Created On
@@ -15421,7 +15421,7 @@ export const KEY_USER_WITH_RELATION_PERMISSIONS_USERNAME = 'username' as keyof U
  *
  * @see {@link UserWithRelationPermissions} - The TypeScript type definition
  */
-export const KEYS_USER_WITH_RELATION_PERMISSIONS: readonly (keyof UserWithRelationPermissions)[] = [
+export const KEYS_USER_WITH_RELATION_PERMISSIONS = [
   KEY_USER_WITH_RELATION_PERMISSIONS_CREATED_ON,
   KEY_USER_WITH_RELATION_PERMISSIONS_DELETED_ON,
   KEY_USER_WITH_RELATION_PERMISSIONS_EMAIL,
@@ -15437,7 +15437,7 @@ export const KEYS_USER_WITH_RELATION_PERMISSIONS: readonly (keyof UserWithRelati
   KEY_USER_WITH_RELATION_PERMISSIONS_USER_ATTRIBUTES,
   KEY_USER_WITH_RELATION_PERMISSIONS_USER_ID,
   KEY_USER_WITH_RELATION_PERMISSIONS_USERNAME,
-] as const;
+] as const satisfies (keyof UserWithRelationPermissions)[];
 
 /**
  * Location
@@ -15535,11 +15535,11 @@ export const KEY_VALIDATION_ERROR_TYPE = 'type' as keyof ValidationError;
  *
  * @see {@link ValidationError} - The TypeScript type definition
  */
-export const KEYS_VALIDATION_ERROR: readonly (keyof ValidationError)[] = [
+export const KEYS_VALIDATION_ERROR = [
   KEY_VALIDATION_ERROR_LOC,
   KEY_VALIDATION_ERROR_MSG,
   KEY_VALIDATION_ERROR_TYPE,
-] as const;
+] as const satisfies (keyof ValidationError)[];
 
 /**
  * meta property
@@ -15611,10 +15611,10 @@ export const KEY_DOMAIN_AVAILABILITY_LIST_RESULTS = 'results' as keyof DomainAva
  *
  * @see {@link DomainAvailabilityList} - The TypeScript type definition
  */
-export const KEYS_DOMAIN_AVAILABILITY_LIST: readonly (keyof DomainAvailabilityList)[] = [
+export const KEYS_DOMAIN_AVAILABILITY_LIST = [
   KEY_DOMAIN_AVAILABILITY_LIST_META,
   KEY_DOMAIN_AVAILABILITY_LIST_RESULTS,
-] as const;
+] as const satisfies (keyof DomainAvailabilityList)[];
 
 /**
  * Available
@@ -15712,8 +15712,8 @@ export const KEY_DOMAIN_AVAILABILITY_CHECK_REASON = 'reason' as keyof DomainAvai
  *
  * @see {@link DomainAvailabilityCheck} - The TypeScript type definition
  */
-export const KEYS_DOMAIN_AVAILABILITY_CHECK: readonly (keyof DomainAvailabilityCheck)[] = [
+export const KEYS_DOMAIN_AVAILABILITY_CHECK = [
   KEY_DOMAIN_AVAILABILITY_CHECK_AVAILABLE,
   KEY_DOMAIN_AVAILABILITY_CHECK_DOMAIN,
   KEY_DOMAIN_AVAILABILITY_CHECK_REASON,
-] as const;
+] as const satisfies (keyof DomainAvailabilityCheck)[];

--- a/src/helpers/requests.ts
+++ b/src/helpers/requests.ts
@@ -30,7 +30,7 @@
  * Do not edit manually.
  */
 
-import { operations, components } from '../schema';
+import { operations } from '../schema';
 
 import { DomainDnssecDataCreateArray, OrganizationAttributeUpdateArray } from './schemas-arrays';
 

--- a/src/helpers/requests.ts
+++ b/src/helpers/requests.ts
@@ -6,21 +6,21 @@
  * These types ensure that request parameters match the expected API contract.
  *
  * @remarks
- * - Request types follow the pattern: `METHOD_EndpointName_V1_Request`
- * - Parameter types are available as: `METHOD_EndpointName_V1_Request_Parameters_Query`, `METHOD_EndpointName_V1_Request_Parameters_Path`
- * - Request body types are available as: `METHOD_EndpointName_V1_Request_RequestBody`
+ * - Request types follow the pattern: `METHOD_EndpointName_Request`
+ * - Parameter types are available as: `METHOD_EndpointName_Request_Query`, `METHOD_EndpointName_Request_Path`
+ * - Request body types are available as: `METHOD_EndpointName_Request_Body`
  * - All types include comprehensive parameter descriptions from the OpenAPI specification
  * - These types ensure type safety when making API requests
  *
  * @example
  * ```typescript
  * // Using request types for API calls
- * const params: GET_Domains_V1_Request_Parameters_Query = {
+ * const params: GET_Domains_Request_Query = {
  *   limit: 10,
  *   offset: 0
  * };
  * 
- * const body: POST_Domains_V1_Request_RequestBody = {
+ * const body: POST_Domains_Request_Body = {
  *   domain: 'example.com',
  *   period: 1
  * };
@@ -52,11 +52,11 @@ import { OrganizationCredentialExtra, SignupCreate, ContactCreate, DnsZoneCreate
  * @path /v1/auth/client_credentials
  * @param status (query) - Optional status to filter the results
  *
- * @see {@link GET_AuthClientCredentials_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_AuthClientCredentials_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_AuthClientCredentials_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_AuthClientCredentials_Request_Query} - Query parameters type
+ * @see {@link GET_AuthClientCredentials_Request_Path} - Path parameters type
+ * @see {@link GET_AuthClientCredentials_Request_Body} - Request body type
  */
-export type GET_AuthClientCredentials_V1_Request = {
+export type GET_AuthClientCredentials_Request = {
   parameters: {
     query: operations['list_api_keys_v1_auth_client_credentials_get']['parameters']['query'];
   };
@@ -74,7 +74,7 @@ export type GET_AuthClientCredentials_V1_Request = {
  * @path /v1/auth/client_credentials
  * @param status (query) - Optional status to filter the results
  */
-export type GET_AuthClientCredentials_V1_Request_Parameters_Query = GET_AuthClientCredentials_V1_Request['parameters']['query'];
+export type GET_AuthClientCredentials_Request_Query = GET_AuthClientCredentials_Request['parameters']['query'];
 
 /**
  * Request type for POST AuthClientCredentials endpoint
@@ -91,11 +91,11 @@ export type GET_AuthClientCredentials_V1_Request_Parameters_Query = GET_AuthClie
  *
  * @path /v1/auth/client_credentials
  *
- * @see {@link POST_AuthClientCredentials_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link POST_AuthClientCredentials_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link POST_AuthClientCredentials_V1_Request_RequestBody} - Request body type
+ * @see {@link POST_AuthClientCredentials_Request_Query} - Query parameters type
+ * @see {@link POST_AuthClientCredentials_Request_Path} - Path parameters type
+ * @see {@link POST_AuthClientCredentials_Request_Body} - Request body type
  */
-export type POST_AuthClientCredentials_V1_Request = {
+export type POST_AuthClientCredentials_Request = {
   requestBody: OrganizationCredentialExtra;
 }
 /**
@@ -110,7 +110,7 @@ export type POST_AuthClientCredentials_V1_Request = {
  *
  * @path /v1/auth/client_credentials
  */
-export type POST_AuthClientCredentials_V1_Request_RequestBody = POST_AuthClientCredentials_V1_Request['requestBody'];
+export type POST_AuthClientCredentials_Request_Body = POST_AuthClientCredentials_Request['requestBody'];
 
 /**
  * Request type for DELETE AuthClientCredentialsApiKeyId endpoint
@@ -127,11 +127,11 @@ export type POST_AuthClientCredentials_V1_Request_RequestBody = POST_AuthClientC
  *
  * @path /v1/auth/client_credentials/{api_key_id}
  *
- * @see {@link DELETE_AuthClientCredentialsApiKeyId_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link DELETE_AuthClientCredentialsApiKeyId_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link DELETE_AuthClientCredentialsApiKeyId_V1_Request_RequestBody} - Request body type
+ * @see {@link DELETE_AuthClientCredentialsApiKeyId_Request_Query} - Query parameters type
+ * @see {@link DELETE_AuthClientCredentialsApiKeyId_Request_Path} - Path parameters type
+ * @see {@link DELETE_AuthClientCredentialsApiKeyId_Request_Body} - Request body type
  */
-export type DELETE_AuthClientCredentialsApiKeyId_V1_Request = {
+export type DELETE_AuthClientCredentialsApiKeyId_Request = {
   parameters: {
     path: operations['delete_api_key_v1_auth_client_credentials__api_key_id__delete']['parameters']['path'];
   };
@@ -148,7 +148,7 @@ export type DELETE_AuthClientCredentialsApiKeyId_V1_Request = {
  *
  * @path /v1/auth/client_credentials/{api_key_id}
  */
-export type DELETE_AuthClientCredentialsApiKeyId_V1_Request_Parameters_Path = DELETE_AuthClientCredentialsApiKeyId_V1_Request['parameters']['path'];
+export type DELETE_AuthClientCredentialsApiKeyId_Request_Path = DELETE_AuthClientCredentialsApiKeyId_Request['parameters']['path'];
 
 /**
  * Request type for POST AuthLogout endpoint
@@ -165,11 +165,11 @@ export type DELETE_AuthClientCredentialsApiKeyId_V1_Request_Parameters_Path = DE
  *
  * @path /v1/auth/logout
  *
- * @see {@link POST_AuthLogout_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link POST_AuthLogout_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link POST_AuthLogout_V1_Request_RequestBody} - Request body type
+ * @see {@link POST_AuthLogout_Request_Query} - Query parameters type
+ * @see {@link POST_AuthLogout_Request_Path} - Path parameters type
+ * @see {@link POST_AuthLogout_Request_Body} - Request body type
  */
-export type POST_AuthLogout_V1_Request = {
+export type POST_AuthLogout_Request = {
 }
 
 /**
@@ -187,11 +187,11 @@ export type POST_AuthLogout_V1_Request = {
  *
  * @path /v1/auth/signup
  *
- * @see {@link POST_AuthSignup_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link POST_AuthSignup_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link POST_AuthSignup_V1_Request_RequestBody} - Request body type
+ * @see {@link POST_AuthSignup_Request_Query} - Query parameters type
+ * @see {@link POST_AuthSignup_Request_Path} - Path parameters type
+ * @see {@link POST_AuthSignup_Request_Body} - Request body type
  */
-export type POST_AuthSignup_V1_Request = {
+export type POST_AuthSignup_Request = {
   requestBody: SignupCreate;
 }
 /**
@@ -206,7 +206,7 @@ export type POST_AuthSignup_V1_Request = {
  *
  * @path /v1/auth/signup
  */
-export type POST_AuthSignup_V1_Request_RequestBody = POST_AuthSignup_V1_Request['requestBody'];
+export type POST_AuthSignup_Request_Body = POST_AuthSignup_Request['requestBody'];
 
 /**
  * Request type for POST AuthToken endpoint
@@ -223,11 +223,11 @@ export type POST_AuthSignup_V1_Request_RequestBody = POST_AuthSignup_V1_Request[
  *
  * @path /v1/auth/token
  *
- * @see {@link POST_AuthToken_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link POST_AuthToken_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link POST_AuthToken_V1_Request_RequestBody} - Request body type
+ * @see {@link POST_AuthToken_Request_Query} - Query parameters type
+ * @see {@link POST_AuthToken_Request_Path} - Path parameters type
+ * @see {@link POST_AuthToken_Request_Body} - Request body type
  */
-export type POST_AuthToken_V1_Request = {
+export type POST_AuthToken_Request = {
 }
 
 /**
@@ -249,11 +249,11 @@ export type POST_AuthToken_V1_Request = {
 Specify one or more domains to check for availability.
 
  *
- * @see {@link GET_Availability_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_Availability_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_Availability_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_Availability_Request_Query} - Query parameters type
+ * @see {@link GET_Availability_Request_Path} - Path parameters type
+ * @see {@link GET_Availability_Request_Body} - Request body type
  */
-export type GET_Availability_V1_Request = {
+export type GET_Availability_Request = {
   parameters: {
     query: operations['bulk_availability_v1_availability_get']['parameters']['query'];
   };
@@ -273,7 +273,7 @@ export type GET_Availability_V1_Request = {
 Specify one or more domains to check for availability.
 
  */
-export type GET_Availability_V1_Request_Parameters_Query = GET_Availability_V1_Request['parameters']['query'];
+export type GET_Availability_Request_Query = GET_Availability_Request['parameters']['query'];
 
 /**
  * Request type for GET AvailabilityStream endpoint
@@ -294,11 +294,11 @@ export type GET_Availability_V1_Request_Parameters_Query = GET_Availability_V1_R
 Specify one or more domains to check for availability.
 
  *
- * @see {@link GET_AvailabilityStream_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_AvailabilityStream_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_AvailabilityStream_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_AvailabilityStream_Request_Query} - Query parameters type
+ * @see {@link GET_AvailabilityStream_Request_Path} - Path parameters type
+ * @see {@link GET_AvailabilityStream_Request_Body} - Request body type
  */
-export type GET_AvailabilityStream_V1_Request = {
+export type GET_AvailabilityStream_Request = {
   parameters: {
     query: operations['stream_availability_v1_availability_stream_get']['parameters']['query'];
   };
@@ -318,7 +318,7 @@ export type GET_AvailabilityStream_V1_Request = {
 Specify one or more domains to check for availability.
 
  */
-export type GET_AvailabilityStream_V1_Request_Parameters_Query = GET_AvailabilityStream_V1_Request['parameters']['query'];
+export type GET_AvailabilityStream_Request_Query = GET_AvailabilityStream_Request['parameters']['query'];
 
 /**
  * Request type for GET Contacts endpoint
@@ -336,11 +336,11 @@ export type GET_AvailabilityStream_V1_Request_Parameters_Query = GET_Availabilit
  *
  * @path /v1/contacts
  *
- * @see {@link GET_Contacts_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_Contacts_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_Contacts_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_Contacts_Request_Query} - Query parameters type
+ * @see {@link GET_Contacts_Request_Path} - Path parameters type
+ * @see {@link GET_Contacts_Request_Body} - Request body type
  */
-export type GET_Contacts_V1_Request = {
+export type GET_Contacts_Request = {
   parameters: {
     query: operations['get_contacts_v1_contacts_get']['parameters']['query'];
   };
@@ -357,7 +357,7 @@ export type GET_Contacts_V1_Request = {
  *
  * @path /v1/contacts
  */
-export type GET_Contacts_V1_Request_Parameters_Query = GET_Contacts_V1_Request['parameters']['query'];
+export type GET_Contacts_Request_Query = GET_Contacts_Request['parameters']['query'];
 
 /**
  * Request type for POST Contacts endpoint
@@ -375,11 +375,11 @@ export type GET_Contacts_V1_Request_Parameters_Query = GET_Contacts_V1_Request['
  *
  * @path /v1/contacts
  *
- * @see {@link POST_Contacts_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link POST_Contacts_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link POST_Contacts_V1_Request_RequestBody} - Request body type
+ * @see {@link POST_Contacts_Request_Query} - Query parameters type
+ * @see {@link POST_Contacts_Request_Path} - Path parameters type
+ * @see {@link POST_Contacts_Request_Body} - Request body type
  */
-export type POST_Contacts_V1_Request = {
+export type POST_Contacts_Request = {
   requestBody: ContactCreate;
 }
 /**
@@ -394,7 +394,7 @@ export type POST_Contacts_V1_Request = {
  *
  * @path /v1/contacts
  */
-export type POST_Contacts_V1_Request_RequestBody = POST_Contacts_V1_Request['requestBody'];
+export type POST_Contacts_Request_Body = POST_Contacts_Request['requestBody'];
 
 /**
  * Request type for DELETE ContactsContactId endpoint
@@ -412,11 +412,11 @@ export type POST_Contacts_V1_Request_RequestBody = POST_Contacts_V1_Request['req
  *
  * @path /v1/contacts/{contact_id}
  *
- * @see {@link DELETE_ContactsContactId_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link DELETE_ContactsContactId_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link DELETE_ContactsContactId_V1_Request_RequestBody} - Request body type
+ * @see {@link DELETE_ContactsContactId_Request_Query} - Query parameters type
+ * @see {@link DELETE_ContactsContactId_Request_Path} - Path parameters type
+ * @see {@link DELETE_ContactsContactId_Request_Body} - Request body type
  */
-export type DELETE_ContactsContactId_V1_Request = {
+export type DELETE_ContactsContactId_Request = {
   parameters: {
     path: operations['delete_contact_v1_contacts__contact_id__delete']['parameters']['path'];
   };
@@ -433,7 +433,7 @@ export type DELETE_ContactsContactId_V1_Request = {
  *
  * @path /v1/contacts/{contact_id}
  */
-export type DELETE_ContactsContactId_V1_Request_Parameters_Path = DELETE_ContactsContactId_V1_Request['parameters']['path'];
+export type DELETE_ContactsContactId_Request_Path = DELETE_ContactsContactId_Request['parameters']['path'];
 
 /**
  * Request type for GET ContactsContactId endpoint
@@ -451,11 +451,11 @@ export type DELETE_ContactsContactId_V1_Request_Parameters_Path = DELETE_Contact
  *
  * @path /v1/contacts/{contact_id}
  *
- * @see {@link GET_ContactsContactId_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_ContactsContactId_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_ContactsContactId_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_ContactsContactId_Request_Query} - Query parameters type
+ * @see {@link GET_ContactsContactId_Request_Path} - Path parameters type
+ * @see {@link GET_ContactsContactId_Request_Body} - Request body type
  */
-export type GET_ContactsContactId_V1_Request = {
+export type GET_ContactsContactId_Request = {
   parameters: {
     path: operations['get_contact_v1_contacts__contact_id__get']['parameters']['path'];
   };
@@ -472,7 +472,7 @@ export type GET_ContactsContactId_V1_Request = {
  *
  * @path /v1/contacts/{contact_id}
  */
-export type GET_ContactsContactId_V1_Request_Parameters_Path = GET_ContactsContactId_V1_Request['parameters']['path'];
+export type GET_ContactsContactId_Request_Path = GET_ContactsContactId_Request['parameters']['path'];
 
 /**
  * Request type for DELETE ContactsContactIdVerification endpoint
@@ -490,11 +490,11 @@ export type GET_ContactsContactId_V1_Request_Parameters_Path = GET_ContactsConta
  *
  * @path /v1/contacts/{contact_id}/verification
  *
- * @see {@link DELETE_ContactsContactIdVerification_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link DELETE_ContactsContactIdVerification_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link DELETE_ContactsContactIdVerification_V1_Request_RequestBody} - Request body type
+ * @see {@link DELETE_ContactsContactIdVerification_Request_Query} - Query parameters type
+ * @see {@link DELETE_ContactsContactIdVerification_Request_Path} - Path parameters type
+ * @see {@link DELETE_ContactsContactIdVerification_Request_Body} - Request body type
  */
-export type DELETE_ContactsContactIdVerification_V1_Request = {
+export type DELETE_ContactsContactIdVerification_Request = {
   parameters: {
     path: operations['cancel_verification_v1_contacts__contact_id__verification_delete']['parameters']['path'];
   };
@@ -511,7 +511,7 @@ export type DELETE_ContactsContactIdVerification_V1_Request = {
  *
  * @path /v1/contacts/{contact_id}/verification
  */
-export type DELETE_ContactsContactIdVerification_V1_Request_Parameters_Path = DELETE_ContactsContactIdVerification_V1_Request['parameters']['path'];
+export type DELETE_ContactsContactIdVerification_Request_Path = DELETE_ContactsContactIdVerification_Request['parameters']['path'];
 
 /**
  * Request type for GET ContactsContactIdVerification endpoint
@@ -529,11 +529,11 @@ export type DELETE_ContactsContactIdVerification_V1_Request_Parameters_Path = DE
  *
  * @path /v1/contacts/{contact_id}/verification
  *
- * @see {@link GET_ContactsContactIdVerification_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_ContactsContactIdVerification_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_ContactsContactIdVerification_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_ContactsContactIdVerification_Request_Query} - Query parameters type
+ * @see {@link GET_ContactsContactIdVerification_Request_Path} - Path parameters type
+ * @see {@link GET_ContactsContactIdVerification_Request_Body} - Request body type
  */
-export type GET_ContactsContactIdVerification_V1_Request = {
+export type GET_ContactsContactIdVerification_Request = {
   parameters: {
     path: operations['get_verification_status_v1_contacts__contact_id__verification_get']['parameters']['path'];
   };
@@ -550,7 +550,7 @@ export type GET_ContactsContactIdVerification_V1_Request = {
  *
  * @path /v1/contacts/{contact_id}/verification
  */
-export type GET_ContactsContactIdVerification_V1_Request_Parameters_Path = GET_ContactsContactIdVerification_V1_Request['parameters']['path'];
+export type GET_ContactsContactIdVerification_Request_Path = GET_ContactsContactIdVerification_Request['parameters']['path'];
 
 /**
  * Request type for POST ContactsContactIdVerification endpoint
@@ -568,11 +568,11 @@ export type GET_ContactsContactIdVerification_V1_Request_Parameters_Path = GET_C
  *
  * @path /v1/contacts/{contact_id}/verification
  *
- * @see {@link POST_ContactsContactIdVerification_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link POST_ContactsContactIdVerification_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link POST_ContactsContactIdVerification_V1_Request_RequestBody} - Request body type
+ * @see {@link POST_ContactsContactIdVerification_Request_Query} - Query parameters type
+ * @see {@link POST_ContactsContactIdVerification_Request_Path} - Path parameters type
+ * @see {@link POST_ContactsContactIdVerification_Request_Body} - Request body type
  */
-export type POST_ContactsContactIdVerification_V1_Request = {
+export type POST_ContactsContactIdVerification_Request = {
   parameters: {
     query: operations['start_contact_verification_v1_contacts__contact_id__verification_post']['parameters']['query'];
     path: operations['start_contact_verification_v1_contacts__contact_id__verification_post']['parameters']['path'];
@@ -590,7 +590,7 @@ export type POST_ContactsContactIdVerification_V1_Request = {
  *
  * @path /v1/contacts/{contact_id}/verification
  */
-export type POST_ContactsContactIdVerification_V1_Request_Parameters_Query = POST_ContactsContactIdVerification_V1_Request['parameters']['query'];
+export type POST_ContactsContactIdVerification_Request_Query = POST_ContactsContactIdVerification_Request['parameters']['query'];
 /**
  * Path parameters for POST /v1/contacts/{contact_id}/verification
  *
@@ -603,7 +603,7 @@ export type POST_ContactsContactIdVerification_V1_Request_Parameters_Query = POS
  *
  * @path /v1/contacts/{contact_id}/verification
  */
-export type POST_ContactsContactIdVerification_V1_Request_Parameters_Path = POST_ContactsContactIdVerification_V1_Request['parameters']['path'];
+export type POST_ContactsContactIdVerification_Request_Path = POST_ContactsContactIdVerification_Request['parameters']['path'];
 
 /**
  * Request type for PUT ContactsContactIdVerification endpoint
@@ -621,11 +621,11 @@ export type POST_ContactsContactIdVerification_V1_Request_Parameters_Path = POST
  *
  * @path /v1/contacts/{contact_id}/verification
  *
- * @see {@link PUT_ContactsContactIdVerification_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link PUT_ContactsContactIdVerification_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link PUT_ContactsContactIdVerification_V1_Request_RequestBody} - Request body type
+ * @see {@link PUT_ContactsContactIdVerification_Request_Query} - Query parameters type
+ * @see {@link PUT_ContactsContactIdVerification_Request_Path} - Path parameters type
+ * @see {@link PUT_ContactsContactIdVerification_Request_Body} - Request body type
  */
-export type PUT_ContactsContactIdVerification_V1_Request = {
+export type PUT_ContactsContactIdVerification_Request = {
   parameters: {
     query: operations['update_verification_v1_contacts__contact_id__verification_put']['parameters']['query'];
     path: operations['update_verification_v1_contacts__contact_id__verification_put']['parameters']['path'];
@@ -643,7 +643,7 @@ export type PUT_ContactsContactIdVerification_V1_Request = {
  *
  * @path /v1/contacts/{contact_id}/verification
  */
-export type PUT_ContactsContactIdVerification_V1_Request_Parameters_Query = PUT_ContactsContactIdVerification_V1_Request['parameters']['query'];
+export type PUT_ContactsContactIdVerification_Request_Query = PUT_ContactsContactIdVerification_Request['parameters']['query'];
 /**
  * Path parameters for PUT /v1/contacts/{contact_id}/verification
  *
@@ -656,7 +656,7 @@ export type PUT_ContactsContactIdVerification_V1_Request_Parameters_Query = PUT_
  *
  * @path /v1/contacts/{contact_id}/verification
  */
-export type PUT_ContactsContactIdVerification_V1_Request_Parameters_Path = PUT_ContactsContactIdVerification_V1_Request['parameters']['path'];
+export type PUT_ContactsContactIdVerification_Request_Path = PUT_ContactsContactIdVerification_Request['parameters']['path'];
 
 /**
  * Request type for GET ContactsVerification endpoint
@@ -674,11 +674,11 @@ export type PUT_ContactsContactIdVerification_V1_Request_Parameters_Path = PUT_C
  *
  * @path /v1/contacts/verification
  *
- * @see {@link GET_ContactsVerification_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_ContactsVerification_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_ContactsVerification_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_ContactsVerification_Request_Query} - Query parameters type
+ * @see {@link GET_ContactsVerification_Request_Path} - Path parameters type
+ * @see {@link GET_ContactsVerification_Request_Body} - Request body type
  */
-export type GET_ContactsVerification_V1_Request = {
+export type GET_ContactsVerification_Request = {
   parameters: {
     query: operations['get_verification_by_token_v1_contacts_verification_get']['parameters']['query'];
   };
@@ -695,7 +695,7 @@ export type GET_ContactsVerification_V1_Request = {
  *
  * @path /v1/contacts/verification
  */
-export type GET_ContactsVerification_V1_Request_Parameters_Query = GET_ContactsVerification_V1_Request['parameters']['query'];
+export type GET_ContactsVerification_Request_Query = GET_ContactsVerification_Request['parameters']['query'];
 
 /**
  * Request type for PUT ContactsVerification endpoint
@@ -713,11 +713,11 @@ export type GET_ContactsVerification_V1_Request_Parameters_Query = GET_ContactsV
  *
  * @path /v1/contacts/verification
  *
- * @see {@link PUT_ContactsVerification_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link PUT_ContactsVerification_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link PUT_ContactsVerification_V1_Request_RequestBody} - Request body type
+ * @see {@link PUT_ContactsVerification_Request_Query} - Query parameters type
+ * @see {@link PUT_ContactsVerification_Request_Path} - Path parameters type
+ * @see {@link PUT_ContactsVerification_Request_Body} - Request body type
  */
-export type PUT_ContactsVerification_V1_Request = {
+export type PUT_ContactsVerification_Request = {
   parameters: {
     query: operations['update_verification_by_token_v1_contacts_verification_put']['parameters']['query'];
   };
@@ -734,7 +734,7 @@ export type PUT_ContactsVerification_V1_Request = {
  *
  * @path /v1/contacts/verification
  */
-export type PUT_ContactsVerification_V1_Request_Parameters_Query = PUT_ContactsVerification_V1_Request['parameters']['query'];
+export type PUT_ContactsVerification_Request_Query = PUT_ContactsVerification_Request['parameters']['query'];
 
 /**
  * Request type for GET ContactsVerify endpoint
@@ -751,11 +751,11 @@ export type PUT_ContactsVerification_V1_Request_Parameters_Query = PUT_ContactsV
  *
  * @path /v1/contacts/verify
  *
- * @see {@link GET_ContactsVerify_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_ContactsVerify_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_ContactsVerify_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_ContactsVerify_Request_Query} - Query parameters type
+ * @see {@link GET_ContactsVerify_Request_Path} - Path parameters type
+ * @see {@link GET_ContactsVerify_Request_Body} - Request body type
  */
-export type GET_ContactsVerify_V1_Request = {
+export type GET_ContactsVerify_Request = {
   parameters: {
     query: operations['email_verify_contact_v1_contacts_verify_get']['parameters']['query'];
   };
@@ -772,7 +772,7 @@ export type GET_ContactsVerify_V1_Request = {
  *
  * @path /v1/contacts/verify
  */
-export type GET_ContactsVerify_V1_Request_Parameters_Query = GET_ContactsVerify_V1_Request['parameters']['query'];
+export type GET_ContactsVerify_Request_Query = GET_ContactsVerify_Request['parameters']['query'];
 
 /**
  * Request type for GET Dns endpoint
@@ -789,11 +789,11 @@ export type GET_ContactsVerify_V1_Request_Parameters_Query = GET_ContactsVerify_
  *
  * @path /v1/dns
  *
- * @see {@link GET_Dns_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_Dns_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_Dns_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_Dns_Request_Query} - Query parameters type
+ * @see {@link GET_Dns_Request_Path} - Path parameters type
+ * @see {@link GET_Dns_Request_Body} - Request body type
  */
-export type GET_Dns_V1_Request = {
+export type GET_Dns_Request = {
   parameters: {
     query: operations['list_zones_v1_dns_get']['parameters']['query'];
   };
@@ -810,7 +810,7 @@ export type GET_Dns_V1_Request = {
  *
  * @path /v1/dns
  */
-export type GET_Dns_V1_Request_Parameters_Query = GET_Dns_V1_Request['parameters']['query'];
+export type GET_Dns_Request_Query = GET_Dns_Request['parameters']['query'];
 
 /**
  * Request type for POST Dns endpoint
@@ -827,11 +827,11 @@ export type GET_Dns_V1_Request_Parameters_Query = GET_Dns_V1_Request['parameters
  *
  * @path /v1/dns
  *
- * @see {@link POST_Dns_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link POST_Dns_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link POST_Dns_V1_Request_RequestBody} - Request body type
+ * @see {@link POST_Dns_Request_Query} - Query parameters type
+ * @see {@link POST_Dns_Request_Path} - Path parameters type
+ * @see {@link POST_Dns_Request_Body} - Request body type
  */
-export type POST_Dns_V1_Request = {
+export type POST_Dns_Request = {
   requestBody: DnsZoneCreate;
 }
 /**
@@ -846,7 +846,7 @@ export type POST_Dns_V1_Request = {
  *
  * @path /v1/dns
  */
-export type POST_Dns_V1_Request_RequestBody = POST_Dns_V1_Request['requestBody'];
+export type POST_Dns_Request_Body = POST_Dns_Request['requestBody'];
 
 /**
  * Request type for DELETE DnsZoneName endpoint
@@ -864,11 +864,11 @@ export type POST_Dns_V1_Request_RequestBody = POST_Dns_V1_Request['requestBody']
  * @path /v1/dns/{zone_name}
  * @param zone_name (path) - DNS zone name (trailing dot optional)
  *
- * @see {@link DELETE_DnsZoneName_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link DELETE_DnsZoneName_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link DELETE_DnsZoneName_V1_Request_RequestBody} - Request body type
+ * @see {@link DELETE_DnsZoneName_Request_Query} - Query parameters type
+ * @see {@link DELETE_DnsZoneName_Request_Path} - Path parameters type
+ * @see {@link DELETE_DnsZoneName_Request_Body} - Request body type
  */
-export type DELETE_DnsZoneName_V1_Request = {
+export type DELETE_DnsZoneName_Request = {
   parameters: {
     path: operations['delete_zone_v1_dns__zone_name__delete']['parameters']['path'];
   };
@@ -886,7 +886,7 @@ export type DELETE_DnsZoneName_V1_Request = {
  * @path /v1/dns/{zone_name}
  * @param zone_name (path) - DNS zone name (trailing dot optional)
  */
-export type DELETE_DnsZoneName_V1_Request_Parameters_Path = DELETE_DnsZoneName_V1_Request['parameters']['path'];
+export type DELETE_DnsZoneName_Request_Path = DELETE_DnsZoneName_Request['parameters']['path'];
 
 /**
  * Request type for GET DnsZoneName endpoint
@@ -904,11 +904,11 @@ export type DELETE_DnsZoneName_V1_Request_Parameters_Path = DELETE_DnsZoneName_V
  * @path /v1/dns/{zone_name}
  * @param zone_name (path) - DNS zone name (trailing dot optional)
  *
- * @see {@link GET_DnsZoneName_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_DnsZoneName_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_DnsZoneName_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_DnsZoneName_Request_Query} - Query parameters type
+ * @see {@link GET_DnsZoneName_Request_Path} - Path parameters type
+ * @see {@link GET_DnsZoneName_Request_Body} - Request body type
  */
-export type GET_DnsZoneName_V1_Request = {
+export type GET_DnsZoneName_Request = {
   parameters: {
     path: operations['get_zone_v1_dns__zone_name__get']['parameters']['path'];
   };
@@ -926,7 +926,7 @@ export type GET_DnsZoneName_V1_Request = {
  * @path /v1/dns/{zone_name}
  * @param zone_name (path) - DNS zone name (trailing dot optional)
  */
-export type GET_DnsZoneName_V1_Request_Parameters_Path = GET_DnsZoneName_V1_Request['parameters']['path'];
+export type GET_DnsZoneName_Request_Path = GET_DnsZoneName_Request['parameters']['path'];
 
 /**
  * Request type for POST DnsZoneNameDnssecDisable endpoint
@@ -944,11 +944,11 @@ export type GET_DnsZoneName_V1_Request_Parameters_Path = GET_DnsZoneName_V1_Requ
  * @path /v1/dns/{zone_name}/dnssec/disable
  * @param zone_name (path) - DNS zone name (trailing dot optional)
  *
- * @see {@link POST_DnsZoneNameDnssecDisable_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link POST_DnsZoneNameDnssecDisable_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link POST_DnsZoneNameDnssecDisable_V1_Request_RequestBody} - Request body type
+ * @see {@link POST_DnsZoneNameDnssecDisable_Request_Query} - Query parameters type
+ * @see {@link POST_DnsZoneNameDnssecDisable_Request_Path} - Path parameters type
+ * @see {@link POST_DnsZoneNameDnssecDisable_Request_Body} - Request body type
  */
-export type POST_DnsZoneNameDnssecDisable_V1_Request = {
+export type POST_DnsZoneNameDnssecDisable_Request = {
   parameters: {
     path: operations['disable_dnssec_v1_dns__zone_name__dnssec_disable_post']['parameters']['path'];
   };
@@ -966,7 +966,7 @@ export type POST_DnsZoneNameDnssecDisable_V1_Request = {
  * @path /v1/dns/{zone_name}/dnssec/disable
  * @param zone_name (path) - DNS zone name (trailing dot optional)
  */
-export type POST_DnsZoneNameDnssecDisable_V1_Request_Parameters_Path = POST_DnsZoneNameDnssecDisable_V1_Request['parameters']['path'];
+export type POST_DnsZoneNameDnssecDisable_Request_Path = POST_DnsZoneNameDnssecDisable_Request['parameters']['path'];
 
 /**
  * Request type for POST DnsZoneNameDnssecEnable endpoint
@@ -984,11 +984,11 @@ export type POST_DnsZoneNameDnssecDisable_V1_Request_Parameters_Path = POST_DnsZ
  * @path /v1/dns/{zone_name}/dnssec/enable
  * @param zone_name (path) - DNS zone name (trailing dot optional)
  *
- * @see {@link POST_DnsZoneNameDnssecEnable_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link POST_DnsZoneNameDnssecEnable_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link POST_DnsZoneNameDnssecEnable_V1_Request_RequestBody} - Request body type
+ * @see {@link POST_DnsZoneNameDnssecEnable_Request_Query} - Query parameters type
+ * @see {@link POST_DnsZoneNameDnssecEnable_Request_Path} - Path parameters type
+ * @see {@link POST_DnsZoneNameDnssecEnable_Request_Body} - Request body type
  */
-export type POST_DnsZoneNameDnssecEnable_V1_Request = {
+export type POST_DnsZoneNameDnssecEnable_Request = {
   parameters: {
     path: operations['enable_dnssec_v1_dns__zone_name__dnssec_enable_post']['parameters']['path'];
   };
@@ -1006,7 +1006,7 @@ export type POST_DnsZoneNameDnssecEnable_V1_Request = {
  * @path /v1/dns/{zone_name}/dnssec/enable
  * @param zone_name (path) - DNS zone name (trailing dot optional)
  */
-export type POST_DnsZoneNameDnssecEnable_V1_Request_Parameters_Path = POST_DnsZoneNameDnssecEnable_V1_Request['parameters']['path'];
+export type POST_DnsZoneNameDnssecEnable_Request_Path = POST_DnsZoneNameDnssecEnable_Request['parameters']['path'];
 
 /**
  * Request type for PATCH DnsZoneNameRecords endpoint
@@ -1024,11 +1024,11 @@ export type POST_DnsZoneNameDnssecEnable_V1_Request_Parameters_Path = POST_DnsZo
  * @path /v1/dns/{zone_name}/records
  * @param zone_name (path) - DNS zone name (trailing dot optional)
  *
- * @see {@link PATCH_DnsZoneNameRecords_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link PATCH_DnsZoneNameRecords_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link PATCH_DnsZoneNameRecords_V1_Request_RequestBody} - Request body type
+ * @see {@link PATCH_DnsZoneNameRecords_Request_Query} - Query parameters type
+ * @see {@link PATCH_DnsZoneNameRecords_Request_Path} - Path parameters type
+ * @see {@link PATCH_DnsZoneNameRecords_Request_Body} - Request body type
  */
-export type PATCH_DnsZoneNameRecords_V1_Request = {
+export type PATCH_DnsZoneNameRecords_Request = {
   parameters: {
     path: operations['patch_zone_records_v1_dns__zone_name__records_patch']['parameters']['path'];
   };
@@ -1047,7 +1047,7 @@ export type PATCH_DnsZoneNameRecords_V1_Request = {
  * @path /v1/dns/{zone_name}/records
  * @param zone_name (path) - DNS zone name (trailing dot optional)
  */
-export type PATCH_DnsZoneNameRecords_V1_Request_Parameters_Path = PATCH_DnsZoneNameRecords_V1_Request['parameters']['path'];
+export type PATCH_DnsZoneNameRecords_Request_Path = PATCH_DnsZoneNameRecords_Request['parameters']['path'];
 /**
  * Request body for PATCH /v1/dns/{zone_name}/records
  *
@@ -1060,7 +1060,7 @@ export type PATCH_DnsZoneNameRecords_V1_Request_Parameters_Path = PATCH_DnsZoneN
  *
  * @path /v1/dns/{zone_name}/records
  */
-export type PATCH_DnsZoneNameRecords_V1_Request_RequestBody = PATCH_DnsZoneNameRecords_V1_Request['requestBody'];
+export type PATCH_DnsZoneNameRecords_Request_Body = PATCH_DnsZoneNameRecords_Request['requestBody'];
 
 /**
  * Request type for PATCH DnsZoneNameRrsets endpoint
@@ -1078,11 +1078,11 @@ export type PATCH_DnsZoneNameRecords_V1_Request_RequestBody = PATCH_DnsZoneNameR
  * @path /v1/dns/{zone_name}/rrsets
  * @param zone_name (path) - DNS zone name (trailing dot optional)
  *
- * @see {@link PATCH_DnsZoneNameRrsets_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link PATCH_DnsZoneNameRrsets_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link PATCH_DnsZoneNameRrsets_V1_Request_RequestBody} - Request body type
+ * @see {@link PATCH_DnsZoneNameRrsets_Request_Query} - Query parameters type
+ * @see {@link PATCH_DnsZoneNameRrsets_Request_Path} - Path parameters type
+ * @see {@link PATCH_DnsZoneNameRrsets_Request_Body} - Request body type
  */
-export type PATCH_DnsZoneNameRrsets_V1_Request = {
+export type PATCH_DnsZoneNameRrsets_Request = {
   parameters: {
     path: operations['patch_zone_rrsets_v1_dns__zone_name__rrsets_patch']['parameters']['path'];
   };
@@ -1101,7 +1101,7 @@ export type PATCH_DnsZoneNameRrsets_V1_Request = {
  * @path /v1/dns/{zone_name}/rrsets
  * @param zone_name (path) - DNS zone name (trailing dot optional)
  */
-export type PATCH_DnsZoneNameRrsets_V1_Request_Parameters_Path = PATCH_DnsZoneNameRrsets_V1_Request['parameters']['path'];
+export type PATCH_DnsZoneNameRrsets_Request_Path = PATCH_DnsZoneNameRrsets_Request['parameters']['path'];
 /**
  * Request body for PATCH /v1/dns/{zone_name}/rrsets
  *
@@ -1114,7 +1114,7 @@ export type PATCH_DnsZoneNameRrsets_V1_Request_Parameters_Path = PATCH_DnsZoneNa
  *
  * @path /v1/dns/{zone_name}/rrsets
  */
-export type PATCH_DnsZoneNameRrsets_V1_Request_RequestBody = PATCH_DnsZoneNameRrsets_V1_Request['requestBody'];
+export type PATCH_DnsZoneNameRrsets_Request_Body = PATCH_DnsZoneNameRrsets_Request['requestBody'];
 
 /**
  * Request type for PUT DnsZoneNameRrsets endpoint
@@ -1132,11 +1132,11 @@ export type PATCH_DnsZoneNameRrsets_V1_Request_RequestBody = PATCH_DnsZoneNameRr
  * @path /v1/dns/{zone_name}/rrsets
  * @param zone_name (path) - DNS zone name (trailing dot optional)
  *
- * @see {@link PUT_DnsZoneNameRrsets_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link PUT_DnsZoneNameRrsets_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link PUT_DnsZoneNameRrsets_V1_Request_RequestBody} - Request body type
+ * @see {@link PUT_DnsZoneNameRrsets_Request_Query} - Query parameters type
+ * @see {@link PUT_DnsZoneNameRrsets_Request_Path} - Path parameters type
+ * @see {@link PUT_DnsZoneNameRrsets_Request_Body} - Request body type
  */
-export type PUT_DnsZoneNameRrsets_V1_Request = {
+export type PUT_DnsZoneNameRrsets_Request = {
   parameters: {
     path: operations['update_zone_rrsets_v1_dns__zone_name__rrsets_put']['parameters']['path'];
   };
@@ -1155,7 +1155,7 @@ export type PUT_DnsZoneNameRrsets_V1_Request = {
  * @path /v1/dns/{zone_name}/rrsets
  * @param zone_name (path) - DNS zone name (trailing dot optional)
  */
-export type PUT_DnsZoneNameRrsets_V1_Request_Parameters_Path = PUT_DnsZoneNameRrsets_V1_Request['parameters']['path'];
+export type PUT_DnsZoneNameRrsets_Request_Path = PUT_DnsZoneNameRrsets_Request['parameters']['path'];
 /**
  * Request body for PUT /v1/dns/{zone_name}/rrsets
  *
@@ -1168,7 +1168,7 @@ export type PUT_DnsZoneNameRrsets_V1_Request_Parameters_Path = PUT_DnsZoneNameRr
  *
  * @path /v1/dns/{zone_name}/rrsets
  */
-export type PUT_DnsZoneNameRrsets_V1_Request_RequestBody = PUT_DnsZoneNameRrsets_V1_Request['requestBody'];
+export type PUT_DnsZoneNameRrsets_Request_Body = PUT_DnsZoneNameRrsets_Request['requestBody'];
 
 /**
  * Request type for GET DomainSearchSuggest endpoint
@@ -1191,11 +1191,11 @@ Specify one or more TLDs to include in the search.
  * @param limit (query) - The maximum number of domain suggestions to return
  * @param premium (query) - Whether to include premium domains in the suggestions
  *
- * @see {@link GET_DomainSearchSuggest_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_DomainSearchSuggest_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_DomainSearchSuggest_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_DomainSearchSuggest_Request_Query} - Query parameters type
+ * @see {@link GET_DomainSearchSuggest_Request_Path} - Path parameters type
+ * @see {@link GET_DomainSearchSuggest_Request_Body} - Request body type
  */
-export type GET_DomainSearchSuggest_V1_Request = {
+export type GET_DomainSearchSuggest_Request = {
   parameters: {
     query: operations['suggest_v1_domain_search_suggest_get']['parameters']['query'];
   };
@@ -1218,7 +1218,7 @@ Specify one or more TLDs to include in the search.
  * @param limit (query) - The maximum number of domain suggestions to return
  * @param premium (query) - Whether to include premium domains in the suggestions
  */
-export type GET_DomainSearchSuggest_V1_Request_Parameters_Query = GET_DomainSearchSuggest_V1_Request['parameters']['query'];
+export type GET_DomainSearchSuggest_Request_Query = GET_DomainSearchSuggest_Request['parameters']['query'];
 
 /**
  * Request type for GET Domains endpoint
@@ -1236,11 +1236,11 @@ export type GET_DomainSearchSuggest_V1_Request_Parameters_Query = GET_DomainSear
  *
  * @path /v1/domains
  *
- * @see {@link GET_Domains_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_Domains_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_Domains_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_Domains_Request_Query} - Query parameters type
+ * @see {@link GET_Domains_Request_Path} - Path parameters type
+ * @see {@link GET_Domains_Request_Body} - Request body type
  */
-export type GET_Domains_V1_Request = {
+export type GET_Domains_Request = {
   parameters: {
     query: operations['get_domains_v1_domains_get']['parameters']['query'];
   };
@@ -1257,7 +1257,7 @@ export type GET_Domains_V1_Request = {
  *
  * @path /v1/domains
  */
-export type GET_Domains_V1_Request_Parameters_Query = GET_Domains_V1_Request['parameters']['query'];
+export type GET_Domains_Request_Query = GET_Domains_Request['parameters']['query'];
 
 /**
  * Request type for POST Domains endpoint
@@ -1275,11 +1275,11 @@ export type GET_Domains_V1_Request_Parameters_Query = GET_Domains_V1_Request['pa
  *
  * @path /v1/domains
  *
- * @see {@link POST_Domains_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link POST_Domains_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link POST_Domains_V1_Request_RequestBody} - Request body type
+ * @see {@link POST_Domains_Request_Query} - Query parameters type
+ * @see {@link POST_Domains_Request_Path} - Path parameters type
+ * @see {@link POST_Domains_Request_Body} - Request body type
  */
-export type POST_Domains_V1_Request = {
+export type POST_Domains_Request = {
   requestBody: DomainCreate;
 }
 /**
@@ -1294,7 +1294,7 @@ export type POST_Domains_V1_Request = {
  *
  * @path /v1/domains
  */
-export type POST_Domains_V1_Request_RequestBody = POST_Domains_V1_Request['requestBody'];
+export type POST_Domains_Request_Body = POST_Domains_Request['requestBody'];
 
 /**
  * Request type for GET DomainsCheck endpoint
@@ -1314,11 +1314,11 @@ export type POST_Domains_V1_Request_RequestBody = POST_Domains_V1_Request['reque
 Specify one or more domains to check for availability.
 
  *
- * @see {@link GET_DomainsCheck_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_DomainsCheck_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_DomainsCheck_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_DomainsCheck_Request_Query} - Query parameters type
+ * @see {@link GET_DomainsCheck_Request_Path} - Path parameters type
+ * @see {@link GET_DomainsCheck_Request_Body} - Request body type
  */
-export type GET_DomainsCheck_V1_Request = {
+export type GET_DomainsCheck_Request = {
   parameters: {
     query: operations['epp_check_domain_v1_domains_check_get']['parameters']['query'];
   };
@@ -1338,7 +1338,7 @@ export type GET_DomainsCheck_V1_Request = {
 Specify one or more domains to check for availability.
 
  */
-export type GET_DomainsCheck_V1_Request_Parameters_Query = GET_DomainsCheck_V1_Request['parameters']['query'];
+export type GET_DomainsCheck_Request_Query = GET_DomainsCheck_Request['parameters']['query'];
 
 /**
  * Request type for DELETE DomainsDomainReference endpoint
@@ -1357,11 +1357,11 @@ and will enter a redemption period during which it may be restored.
  *
  * @path /v1/domains/{domain_reference}
  *
- * @see {@link DELETE_DomainsDomainReference_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link DELETE_DomainsDomainReference_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link DELETE_DomainsDomainReference_V1_Request_RequestBody} - Request body type
+ * @see {@link DELETE_DomainsDomainReference_Request_Query} - Query parameters type
+ * @see {@link DELETE_DomainsDomainReference_Request_Path} - Path parameters type
+ * @see {@link DELETE_DomainsDomainReference_Request_Body} - Request body type
  */
-export type DELETE_DomainsDomainReference_V1_Request = {
+export type DELETE_DomainsDomainReference_Request = {
   parameters: {
     path: operations['delete_domain_v1_domains__domain_reference__delete']['parameters']['path'];
   };
@@ -1378,7 +1378,7 @@ export type DELETE_DomainsDomainReference_V1_Request = {
  *
  * @path /v1/domains/{domain_reference}
  */
-export type DELETE_DomainsDomainReference_V1_Request_Parameters_Path = DELETE_DomainsDomainReference_V1_Request['parameters']['path'];
+export type DELETE_DomainsDomainReference_Request_Path = DELETE_DomainsDomainReference_Request['parameters']['path'];
 
 /**
  * Request type for GET DomainsDomainReference endpoint
@@ -1396,11 +1396,11 @@ export type DELETE_DomainsDomainReference_V1_Request_Parameters_Path = DELETE_Do
  *
  * @path /v1/domains/{domain_reference}
  *
- * @see {@link GET_DomainsDomainReference_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_DomainsDomainReference_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_DomainsDomainReference_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_DomainsDomainReference_Request_Query} - Query parameters type
+ * @see {@link GET_DomainsDomainReference_Request_Path} - Path parameters type
+ * @see {@link GET_DomainsDomainReference_Request_Body} - Request body type
  */
-export type GET_DomainsDomainReference_V1_Request = {
+export type GET_DomainsDomainReference_Request = {
   parameters: {
     path: operations['get_domain_v1_domains__domain_reference__get']['parameters']['path'];
   };
@@ -1417,7 +1417,7 @@ export type GET_DomainsDomainReference_V1_Request = {
  *
  * @path /v1/domains/{domain_reference}
  */
-export type GET_DomainsDomainReference_V1_Request_Parameters_Path = GET_DomainsDomainReference_V1_Request['parameters']['path'];
+export type GET_DomainsDomainReference_Request_Path = GET_DomainsDomainReference_Request['parameters']['path'];
 
 /**
  * Request type for PATCH DomainsDomainReference endpoint
@@ -1437,11 +1437,11 @@ Providing `clientTransferProhibited` as a status will set the `transfer_lock` pr
  *
  * @path /v1/domains/{domain_reference}
  *
- * @see {@link PATCH_DomainsDomainReference_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link PATCH_DomainsDomainReference_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link PATCH_DomainsDomainReference_V1_Request_RequestBody} - Request body type
+ * @see {@link PATCH_DomainsDomainReference_Request_Query} - Query parameters type
+ * @see {@link PATCH_DomainsDomainReference_Request_Path} - Path parameters type
+ * @see {@link PATCH_DomainsDomainReference_Request_Body} - Request body type
  */
-export type PATCH_DomainsDomainReference_V1_Request = {
+export type PATCH_DomainsDomainReference_Request = {
   parameters: {
     path: operations['update_domain_v1_domains__domain_reference__patch']['parameters']['path'];
   };
@@ -1459,7 +1459,7 @@ export type PATCH_DomainsDomainReference_V1_Request = {
  *
  * @path /v1/domains/{domain_reference}
  */
-export type PATCH_DomainsDomainReference_V1_Request_Parameters_Path = PATCH_DomainsDomainReference_V1_Request['parameters']['path'];
+export type PATCH_DomainsDomainReference_Request_Path = PATCH_DomainsDomainReference_Request['parameters']['path'];
 /**
  * Request body for PATCH /v1/domains/{domain_reference}
  *
@@ -1472,7 +1472,7 @@ export type PATCH_DomainsDomainReference_V1_Request_Parameters_Path = PATCH_Doma
  *
  * @path /v1/domains/{domain_reference}
  */
-export type PATCH_DomainsDomainReference_V1_Request_RequestBody = PATCH_DomainsDomainReference_V1_Request['requestBody'];
+export type PATCH_DomainsDomainReference_Request_Body = PATCH_DomainsDomainReference_Request['requestBody'];
 
 /**
  * Request type for DELETE DomainsDomainReferenceDnssec endpoint
@@ -1490,11 +1490,11 @@ export type PATCH_DomainsDomainReference_V1_Request_RequestBody = PATCH_DomainsD
  *
  * @path /v1/domains/{domain_reference}/dnssec
  *
- * @see {@link DELETE_DomainsDomainReferenceDnssec_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link DELETE_DomainsDomainReferenceDnssec_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link DELETE_DomainsDomainReferenceDnssec_V1_Request_RequestBody} - Request body type
+ * @see {@link DELETE_DomainsDomainReferenceDnssec_Request_Query} - Query parameters type
+ * @see {@link DELETE_DomainsDomainReferenceDnssec_Request_Path} - Path parameters type
+ * @see {@link DELETE_DomainsDomainReferenceDnssec_Request_Body} - Request body type
  */
-export type DELETE_DomainsDomainReferenceDnssec_V1_Request = {
+export type DELETE_DomainsDomainReferenceDnssec_Request = {
   parameters: {
     path: operations['delete_dnssec_v1_domains__domain_reference__dnssec_delete']['parameters']['path'];
   };
@@ -1511,7 +1511,7 @@ export type DELETE_DomainsDomainReferenceDnssec_V1_Request = {
  *
  * @path /v1/domains/{domain_reference}/dnssec
  */
-export type DELETE_DomainsDomainReferenceDnssec_V1_Request_Parameters_Path = DELETE_DomainsDomainReferenceDnssec_V1_Request['parameters']['path'];
+export type DELETE_DomainsDomainReferenceDnssec_Request_Path = DELETE_DomainsDomainReferenceDnssec_Request['parameters']['path'];
 
 /**
  * Request type for GET DomainsDomainReferenceDnssec endpoint
@@ -1529,11 +1529,11 @@ export type DELETE_DomainsDomainReferenceDnssec_V1_Request_Parameters_Path = DEL
  *
  * @path /v1/domains/{domain_reference}/dnssec
  *
- * @see {@link GET_DomainsDomainReferenceDnssec_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_DomainsDomainReferenceDnssec_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_DomainsDomainReferenceDnssec_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_DomainsDomainReferenceDnssec_Request_Query} - Query parameters type
+ * @see {@link GET_DomainsDomainReferenceDnssec_Request_Path} - Path parameters type
+ * @see {@link GET_DomainsDomainReferenceDnssec_Request_Body} - Request body type
  */
-export type GET_DomainsDomainReferenceDnssec_V1_Request = {
+export type GET_DomainsDomainReferenceDnssec_Request = {
   parameters: {
     path: operations['get_dnssec_v1_domains__domain_reference__dnssec_get']['parameters']['path'];
   };
@@ -1550,7 +1550,7 @@ export type GET_DomainsDomainReferenceDnssec_V1_Request = {
  *
  * @path /v1/domains/{domain_reference}/dnssec
  */
-export type GET_DomainsDomainReferenceDnssec_V1_Request_Parameters_Path = GET_DomainsDomainReferenceDnssec_V1_Request['parameters']['path'];
+export type GET_DomainsDomainReferenceDnssec_Request_Path = GET_DomainsDomainReferenceDnssec_Request['parameters']['path'];
 
 /**
  * Request type for PUT DomainsDomainReferenceDnssec endpoint
@@ -1568,11 +1568,11 @@ export type GET_DomainsDomainReferenceDnssec_V1_Request_Parameters_Path = GET_Do
  *
  * @path /v1/domains/{domain_reference}/dnssec
  *
- * @see {@link PUT_DomainsDomainReferenceDnssec_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link PUT_DomainsDomainReferenceDnssec_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link PUT_DomainsDomainReferenceDnssec_V1_Request_RequestBody} - Request body type
+ * @see {@link PUT_DomainsDomainReferenceDnssec_Request_Query} - Query parameters type
+ * @see {@link PUT_DomainsDomainReferenceDnssec_Request_Path} - Path parameters type
+ * @see {@link PUT_DomainsDomainReferenceDnssec_Request_Body} - Request body type
  */
-export type PUT_DomainsDomainReferenceDnssec_V1_Request = {
+export type PUT_DomainsDomainReferenceDnssec_Request = {
   parameters: {
     path: operations['create_or_update_dnssec_v1_domains__domain_reference__dnssec_put']['parameters']['path'];
   };
@@ -1590,7 +1590,7 @@ export type PUT_DomainsDomainReferenceDnssec_V1_Request = {
  *
  * @path /v1/domains/{domain_reference}/dnssec
  */
-export type PUT_DomainsDomainReferenceDnssec_V1_Request_Parameters_Path = PUT_DomainsDomainReferenceDnssec_V1_Request['parameters']['path'];
+export type PUT_DomainsDomainReferenceDnssec_Request_Path = PUT_DomainsDomainReferenceDnssec_Request['parameters']['path'];
 /**
  * Request body for PUT /v1/domains/{domain_reference}/dnssec
  *
@@ -1603,7 +1603,7 @@ export type PUT_DomainsDomainReferenceDnssec_V1_Request_Parameters_Path = PUT_Do
  *
  * @path /v1/domains/{domain_reference}/dnssec
  */
-export type PUT_DomainsDomainReferenceDnssec_V1_Request_RequestBody = PUT_DomainsDomainReferenceDnssec_V1_Request['requestBody'];
+export type PUT_DomainsDomainReferenceDnssec_Request_Body = PUT_DomainsDomainReferenceDnssec_Request['requestBody'];
 
 /**
  * Request type for POST DomainsDomainReferenceRenew endpoint
@@ -1622,11 +1622,11 @@ to the current expiration date of the domain.
  *
  * @path /v1/domains/{domain_reference}/renew
  *
- * @see {@link POST_DomainsDomainReferenceRenew_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link POST_DomainsDomainReferenceRenew_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link POST_DomainsDomainReferenceRenew_V1_Request_RequestBody} - Request body type
+ * @see {@link POST_DomainsDomainReferenceRenew_Request_Query} - Query parameters type
+ * @see {@link POST_DomainsDomainReferenceRenew_Request_Path} - Path parameters type
+ * @see {@link POST_DomainsDomainReferenceRenew_Request_Body} - Request body type
  */
-export type POST_DomainsDomainReferenceRenew_V1_Request = {
+export type POST_DomainsDomainReferenceRenew_Request = {
   parameters: {
     path: operations['renew_domain_v1_domains__domain_reference__renew_post']['parameters']['path'];
   };
@@ -1644,7 +1644,7 @@ export type POST_DomainsDomainReferenceRenew_V1_Request = {
  *
  * @path /v1/domains/{domain_reference}/renew
  */
-export type POST_DomainsDomainReferenceRenew_V1_Request_Parameters_Path = POST_DomainsDomainReferenceRenew_V1_Request['parameters']['path'];
+export type POST_DomainsDomainReferenceRenew_Request_Path = POST_DomainsDomainReferenceRenew_Request['parameters']['path'];
 /**
  * Request body for POST /v1/domains/{domain_reference}/renew
  *
@@ -1657,7 +1657,7 @@ export type POST_DomainsDomainReferenceRenew_V1_Request_Parameters_Path = POST_D
  *
  * @path /v1/domains/{domain_reference}/renew
  */
-export type POST_DomainsDomainReferenceRenew_V1_Request_RequestBody = POST_DomainsDomainReferenceRenew_V1_Request['requestBody'];
+export type POST_DomainsDomainReferenceRenew_Request_Body = POST_DomainsDomainReferenceRenew_Request['requestBody'];
 
 /**
  * Request type for DELETE DomainsDomainReferenceTransfer endpoint
@@ -1675,11 +1675,11 @@ export type POST_DomainsDomainReferenceRenew_V1_Request_RequestBody = POST_Domai
  *
  * @path /v1/domains/{domain_reference}/transfer
  *
- * @see {@link DELETE_DomainsDomainReferenceTransfer_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link DELETE_DomainsDomainReferenceTransfer_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link DELETE_DomainsDomainReferenceTransfer_V1_Request_RequestBody} - Request body type
+ * @see {@link DELETE_DomainsDomainReferenceTransfer_Request_Query} - Query parameters type
+ * @see {@link DELETE_DomainsDomainReferenceTransfer_Request_Path} - Path parameters type
+ * @see {@link DELETE_DomainsDomainReferenceTransfer_Request_Body} - Request body type
  */
-export type DELETE_DomainsDomainReferenceTransfer_V1_Request = {
+export type DELETE_DomainsDomainReferenceTransfer_Request = {
   parameters: {
     path: operations['cancel_domain_transfer_v1_domains__domain_reference__transfer_delete']['parameters']['path'];
   };
@@ -1696,7 +1696,7 @@ export type DELETE_DomainsDomainReferenceTransfer_V1_Request = {
  *
  * @path /v1/domains/{domain_reference}/transfer
  */
-export type DELETE_DomainsDomainReferenceTransfer_V1_Request_Parameters_Path = DELETE_DomainsDomainReferenceTransfer_V1_Request['parameters']['path'];
+export type DELETE_DomainsDomainReferenceTransfer_Request_Path = DELETE_DomainsDomainReferenceTransfer_Request['parameters']['path'];
 
 /**
  * Request type for GET DomainsSummary endpoint
@@ -1714,11 +1714,11 @@ export type DELETE_DomainsDomainReferenceTransfer_V1_Request_Parameters_Path = D
  *
  * @path /v1/domains/summary
  *
- * @see {@link GET_DomainsSummary_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_DomainsSummary_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_DomainsSummary_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_DomainsSummary_Request_Query} - Query parameters type
+ * @see {@link GET_DomainsSummary_Request_Path} - Path parameters type
+ * @see {@link GET_DomainsSummary_Request_Body} - Request body type
  */
-export type GET_DomainsSummary_V1_Request = {
+export type GET_DomainsSummary_Request = {
 }
 
 /**
@@ -1739,11 +1739,11 @@ This process can take up to 5 days, until the transfer is approved
  *
  * @path /v1/domains/transfer
  *
- * @see {@link POST_DomainsTransfer_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link POST_DomainsTransfer_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link POST_DomainsTransfer_V1_Request_RequestBody} - Request body type
+ * @see {@link POST_DomainsTransfer_Request_Query} - Query parameters type
+ * @see {@link POST_DomainsTransfer_Request_Path} - Path parameters type
+ * @see {@link POST_DomainsTransfer_Request_Body} - Request body type
  */
-export type POST_DomainsTransfer_V1_Request = {
+export type POST_DomainsTransfer_Request = {
   requestBody: DomainTransferIn;
 }
 /**
@@ -1758,7 +1758,7 @@ export type POST_DomainsTransfer_V1_Request = {
  *
  * @path /v1/domains/transfer
  */
-export type POST_DomainsTransfer_V1_Request_RequestBody = POST_DomainsTransfer_V1_Request['requestBody'];
+export type POST_DomainsTransfer_Request_Body = POST_DomainsTransfer_Request['requestBody'];
 
 /**
  * Request type for GET EmailForwards endpoint
@@ -1778,11 +1778,11 @@ export type POST_DomainsTransfer_V1_Request_RequestBody = POST_DomainsTransfer_V
  * @param source_address (query) - Optional source address to filter the results
  * @param target_address (query) - Optional target address to filter the results
  *
- * @see {@link GET_EmailForwards_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_EmailForwards_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_EmailForwards_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_EmailForwards_Request_Query} - Query parameters type
+ * @see {@link GET_EmailForwards_Request_Path} - Path parameters type
+ * @see {@link GET_EmailForwards_Request_Body} - Request body type
  */
-export type GET_EmailForwards_V1_Request = {
+export type GET_EmailForwards_Request = {
   parameters: {
     query: operations['list_email_forwards_v1_email_forwards_get']['parameters']['query'];
   };
@@ -1802,7 +1802,7 @@ export type GET_EmailForwards_V1_Request = {
  * @param source_address (query) - Optional source address to filter the results
  * @param target_address (query) - Optional target address to filter the results
  */
-export type GET_EmailForwards_V1_Request_Parameters_Query = GET_EmailForwards_V1_Request['parameters']['query'];
+export type GET_EmailForwards_Request_Query = GET_EmailForwards_Request['parameters']['query'];
 
 /**
  * Request type for POST EmailForwards endpoint
@@ -1819,11 +1819,11 @@ export type GET_EmailForwards_V1_Request_Parameters_Query = GET_EmailForwards_V1
  *
  * @path /v1/email-forwards
  *
- * @see {@link POST_EmailForwards_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link POST_EmailForwards_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link POST_EmailForwards_V1_Request_RequestBody} - Request body type
+ * @see {@link POST_EmailForwards_Request_Query} - Query parameters type
+ * @see {@link POST_EmailForwards_Request_Path} - Path parameters type
+ * @see {@link POST_EmailForwards_Request_Body} - Request body type
  */
-export type POST_EmailForwards_V1_Request = {
+export type POST_EmailForwards_Request = {
   requestBody: EmailForwardCreate;
 }
 /**
@@ -1838,7 +1838,7 @@ export type POST_EmailForwards_V1_Request = {
  *
  * @path /v1/email-forwards
  */
-export type POST_EmailForwards_V1_Request_RequestBody = POST_EmailForwards_V1_Request['requestBody'];
+export type POST_EmailForwards_Request_Body = POST_EmailForwards_Request['requestBody'];
 
 /**
  * Request type for POST EmailForwardsBulkDelete endpoint
@@ -1855,11 +1855,11 @@ export type POST_EmailForwards_V1_Request_RequestBody = POST_EmailForwards_V1_Re
  *
  * @path /v1/email-forwards/bulk-delete
  *
- * @see {@link POST_EmailForwardsBulkDelete_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link POST_EmailForwardsBulkDelete_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link POST_EmailForwardsBulkDelete_V1_Request_RequestBody} - Request body type
+ * @see {@link POST_EmailForwardsBulkDelete_Request_Query} - Query parameters type
+ * @see {@link POST_EmailForwardsBulkDelete_Request_Path} - Path parameters type
+ * @see {@link POST_EmailForwardsBulkDelete_Request_Body} - Request body type
  */
-export type POST_EmailForwardsBulkDelete_V1_Request = {
+export type POST_EmailForwardsBulkDelete_Request = {
   requestBody: EmailForwardBulkDelete;
 }
 /**
@@ -1874,7 +1874,7 @@ export type POST_EmailForwardsBulkDelete_V1_Request = {
  *
  * @path /v1/email-forwards/bulk-delete
  */
-export type POST_EmailForwardsBulkDelete_V1_Request_RequestBody = POST_EmailForwardsBulkDelete_V1_Request['requestBody'];
+export type POST_EmailForwardsBulkDelete_Request_Body = POST_EmailForwardsBulkDelete_Request['requestBody'];
 
 /**
  * Request type for PATCH EmailForwardsBulkUpdate endpoint
@@ -1891,11 +1891,11 @@ export type POST_EmailForwardsBulkDelete_V1_Request_RequestBody = POST_EmailForw
  *
  * @path /v1/email-forwards/bulk-update
  *
- * @see {@link PATCH_EmailForwardsBulkUpdate_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link PATCH_EmailForwardsBulkUpdate_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link PATCH_EmailForwardsBulkUpdate_V1_Request_RequestBody} - Request body type
+ * @see {@link PATCH_EmailForwardsBulkUpdate_Request_Query} - Query parameters type
+ * @see {@link PATCH_EmailForwardsBulkUpdate_Request_Path} - Path parameters type
+ * @see {@link PATCH_EmailForwardsBulkUpdate_Request_Body} - Request body type
  */
-export type PATCH_EmailForwardsBulkUpdate_V1_Request = {
+export type PATCH_EmailForwardsBulkUpdate_Request = {
   requestBody: EmailForwardBulkUpdate;
 }
 /**
@@ -1910,7 +1910,7 @@ export type PATCH_EmailForwardsBulkUpdate_V1_Request = {
  *
  * @path /v1/email-forwards/bulk-update
  */
-export type PATCH_EmailForwardsBulkUpdate_V1_Request_RequestBody = PATCH_EmailForwardsBulkUpdate_V1_Request['requestBody'];
+export type PATCH_EmailForwardsBulkUpdate_Request_Body = PATCH_EmailForwardsBulkUpdate_Request['requestBody'];
 
 /**
  * Request type for DELETE EmailForwardsEmailForwardId endpoint
@@ -1927,11 +1927,11 @@ export type PATCH_EmailForwardsBulkUpdate_V1_Request_RequestBody = PATCH_EmailFo
  *
  * @path /v1/email-forwards/{email_forward_id}
  *
- * @see {@link DELETE_EmailForwardsEmailForwardId_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link DELETE_EmailForwardsEmailForwardId_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link DELETE_EmailForwardsEmailForwardId_V1_Request_RequestBody} - Request body type
+ * @see {@link DELETE_EmailForwardsEmailForwardId_Request_Query} - Query parameters type
+ * @see {@link DELETE_EmailForwardsEmailForwardId_Request_Path} - Path parameters type
+ * @see {@link DELETE_EmailForwardsEmailForwardId_Request_Body} - Request body type
  */
-export type DELETE_EmailForwardsEmailForwardId_V1_Request = {
+export type DELETE_EmailForwardsEmailForwardId_Request = {
   parameters: {
     path: operations['delete_email_forward_v1_email_forwards__email_forward_id__delete']['parameters']['path'];
   };
@@ -1948,7 +1948,7 @@ export type DELETE_EmailForwardsEmailForwardId_V1_Request = {
  *
  * @path /v1/email-forwards/{email_forward_id}
  */
-export type DELETE_EmailForwardsEmailForwardId_V1_Request_Parameters_Path = DELETE_EmailForwardsEmailForwardId_V1_Request['parameters']['path'];
+export type DELETE_EmailForwardsEmailForwardId_Request_Path = DELETE_EmailForwardsEmailForwardId_Request['parameters']['path'];
 
 /**
  * Request type for GET EmailForwardsEmailForwardId endpoint
@@ -1965,11 +1965,11 @@ export type DELETE_EmailForwardsEmailForwardId_V1_Request_Parameters_Path = DELE
  *
  * @path /v1/email-forwards/{email_forward_id}
  *
- * @see {@link GET_EmailForwardsEmailForwardId_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_EmailForwardsEmailForwardId_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_EmailForwardsEmailForwardId_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_EmailForwardsEmailForwardId_Request_Query} - Query parameters type
+ * @see {@link GET_EmailForwardsEmailForwardId_Request_Path} - Path parameters type
+ * @see {@link GET_EmailForwardsEmailForwardId_Request_Body} - Request body type
  */
-export type GET_EmailForwardsEmailForwardId_V1_Request = {
+export type GET_EmailForwardsEmailForwardId_Request = {
   parameters: {
     path: operations['get_email_forward_v1_email_forwards__email_forward_id__get']['parameters']['path'];
   };
@@ -1986,7 +1986,7 @@ export type GET_EmailForwardsEmailForwardId_V1_Request = {
  *
  * @path /v1/email-forwards/{email_forward_id}
  */
-export type GET_EmailForwardsEmailForwardId_V1_Request_Parameters_Path = GET_EmailForwardsEmailForwardId_V1_Request['parameters']['path'];
+export type GET_EmailForwardsEmailForwardId_Request_Path = GET_EmailForwardsEmailForwardId_Request['parameters']['path'];
 
 /**
  * Request type for PATCH EmailForwardsEmailForwardId endpoint
@@ -2003,11 +2003,11 @@ export type GET_EmailForwardsEmailForwardId_V1_Request_Parameters_Path = GET_Ema
  *
  * @path /v1/email-forwards/{email_forward_id}
  *
- * @see {@link PATCH_EmailForwardsEmailForwardId_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link PATCH_EmailForwardsEmailForwardId_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link PATCH_EmailForwardsEmailForwardId_V1_Request_RequestBody} - Request body type
+ * @see {@link PATCH_EmailForwardsEmailForwardId_Request_Query} - Query parameters type
+ * @see {@link PATCH_EmailForwardsEmailForwardId_Request_Path} - Path parameters type
+ * @see {@link PATCH_EmailForwardsEmailForwardId_Request_Body} - Request body type
  */
-export type PATCH_EmailForwardsEmailForwardId_V1_Request = {
+export type PATCH_EmailForwardsEmailForwardId_Request = {
   parameters: {
     path: operations['update_email_forward_v1_email_forwards__email_forward_id__patch']['parameters']['path'];
   };
@@ -2025,7 +2025,7 @@ export type PATCH_EmailForwardsEmailForwardId_V1_Request = {
  *
  * @path /v1/email-forwards/{email_forward_id}
  */
-export type PATCH_EmailForwardsEmailForwardId_V1_Request_Parameters_Path = PATCH_EmailForwardsEmailForwardId_V1_Request['parameters']['path'];
+export type PATCH_EmailForwardsEmailForwardId_Request_Path = PATCH_EmailForwardsEmailForwardId_Request['parameters']['path'];
 /**
  * Request body for PATCH /v1/email-forwards/{email_forward_id}
  *
@@ -2038,7 +2038,7 @@ export type PATCH_EmailForwardsEmailForwardId_V1_Request_Parameters_Path = PATCH
  *
  * @path /v1/email-forwards/{email_forward_id}
  */
-export type PATCH_EmailForwardsEmailForwardId_V1_Request_RequestBody = PATCH_EmailForwardsEmailForwardId_V1_Request['requestBody'];
+export type PATCH_EmailForwardsEmailForwardId_Request_Body = PATCH_EmailForwardsEmailForwardId_Request['requestBody'];
 
 /**
  * Request type for GET Event endpoint
@@ -2055,11 +2055,11 @@ export type PATCH_EmailForwardsEmailForwardId_V1_Request_RequestBody = PATCH_Ema
  *
  * @path /v1/event
  *
- * @see {@link GET_Event_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_Event_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_Event_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_Event_Request_Query} - Query parameters type
+ * @see {@link GET_Event_Request_Path} - Path parameters type
+ * @see {@link GET_Event_Request_Body} - Request body type
  */
-export type GET_Event_V1_Request = {
+export type GET_Event_Request = {
   parameters: {
     query: operations['get_events_v1_event_get']['parameters']['query'];
   };
@@ -2076,7 +2076,7 @@ export type GET_Event_V1_Request = {
  *
  * @path /v1/event
  */
-export type GET_Event_V1_Request_Parameters_Query = GET_Event_V1_Request['parameters']['query'];
+export type GET_Event_Request_Query = GET_Event_Request['parameters']['query'];
 
 /**
  * Request type for GET EventEventId endpoint
@@ -2093,11 +2093,11 @@ export type GET_Event_V1_Request_Parameters_Query = GET_Event_V1_Request['parame
  *
  * @path /v1/event/{event_id}
  *
- * @see {@link GET_EventEventId_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_EventEventId_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_EventEventId_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_EventEventId_Request_Query} - Query parameters type
+ * @see {@link GET_EventEventId_Request_Path} - Path parameters type
+ * @see {@link GET_EventEventId_Request_Body} - Request body type
  */
-export type GET_EventEventId_V1_Request = {
+export type GET_EventEventId_Request = {
   parameters: {
     path: operations['get_event_v1_event__event_id__get']['parameters']['path'];
   };
@@ -2114,7 +2114,7 @@ export type GET_EventEventId_V1_Request = {
  *
  * @path /v1/event/{event_id}
  */
-export type GET_EventEventId_V1_Request_Parameters_Path = GET_EventEventId_V1_Request['parameters']['path'];
+export type GET_EventEventId_Request_Path = GET_EventEventId_Request['parameters']['path'];
 
 /**
  * Request type for PATCH EventEventId endpoint
@@ -2131,11 +2131,11 @@ export type GET_EventEventId_V1_Request_Parameters_Path = GET_EventEventId_V1_Re
  *
  * @path /v1/event/{event_id}
  *
- * @see {@link PATCH_EventEventId_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link PATCH_EventEventId_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link PATCH_EventEventId_V1_Request_RequestBody} - Request body type
+ * @see {@link PATCH_EventEventId_Request_Query} - Query parameters type
+ * @see {@link PATCH_EventEventId_Request_Path} - Path parameters type
+ * @see {@link PATCH_EventEventId_Request_Body} - Request body type
  */
-export type PATCH_EventEventId_V1_Request = {
+export type PATCH_EventEventId_Request = {
   parameters: {
     path: operations['acknowledge_event_v1_event__event_id__patch']['parameters']['path'];
   };
@@ -2152,7 +2152,7 @@ export type PATCH_EventEventId_V1_Request = {
  *
  * @path /v1/event/{event_id}
  */
-export type PATCH_EventEventId_V1_Request_Parameters_Path = PATCH_EventEventId_V1_Request['parameters']['path'];
+export type PATCH_EventEventId_Request_Path = PATCH_EventEventId_Request['parameters']['path'];
 
 /**
  * Request type for GET Notifications endpoint
@@ -2169,11 +2169,11 @@ export type PATCH_EventEventId_V1_Request_Parameters_Path = PATCH_EventEventId_V
  *
  * @path /v1/notifications
  *
- * @see {@link GET_Notifications_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_Notifications_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_Notifications_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_Notifications_Request_Query} - Query parameters type
+ * @see {@link GET_Notifications_Request_Path} - Path parameters type
+ * @see {@link GET_Notifications_Request_Body} - Request body type
  */
-export type GET_Notifications_V1_Request = {
+export type GET_Notifications_Request = {
   parameters: {
     query: operations['list_notifications_v1_notifications_get']['parameters']['query'];
   };
@@ -2190,7 +2190,7 @@ export type GET_Notifications_V1_Request = {
  *
  * @path /v1/notifications
  */
-export type GET_Notifications_V1_Request_Parameters_Query = GET_Notifications_V1_Request['parameters']['query'];
+export type GET_Notifications_Request_Query = GET_Notifications_Request['parameters']['query'];
 
 /**
  * Request type for POST Notifications endpoint
@@ -2207,11 +2207,11 @@ export type GET_Notifications_V1_Request_Parameters_Query = GET_Notifications_V1
  *
  * @path /v1/notifications
  *
- * @see {@link POST_Notifications_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link POST_Notifications_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link POST_Notifications_V1_Request_RequestBody} - Request body type
+ * @see {@link POST_Notifications_Request_Query} - Query parameters type
+ * @see {@link POST_Notifications_Request_Path} - Path parameters type
+ * @see {@link POST_Notifications_Request_Body} - Request body type
  */
-export type POST_Notifications_V1_Request = {
+export type POST_Notifications_Request = {
   requestBody: NotificationCreate;
 }
 /**
@@ -2226,7 +2226,7 @@ export type POST_Notifications_V1_Request = {
  *
  * @path /v1/notifications
  */
-export type POST_Notifications_V1_Request_RequestBody = POST_Notifications_V1_Request['requestBody'];
+export type POST_Notifications_Request_Body = POST_Notifications_Request['requestBody'];
 
 /**
  * Request type for DELETE NotificationsNotificationId endpoint
@@ -2243,11 +2243,11 @@ export type POST_Notifications_V1_Request_RequestBody = POST_Notifications_V1_Re
  *
  * @path /v1/notifications/{notification_id}
  *
- * @see {@link DELETE_NotificationsNotificationId_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link DELETE_NotificationsNotificationId_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link DELETE_NotificationsNotificationId_V1_Request_RequestBody} - Request body type
+ * @see {@link DELETE_NotificationsNotificationId_Request_Query} - Query parameters type
+ * @see {@link DELETE_NotificationsNotificationId_Request_Path} - Path parameters type
+ * @see {@link DELETE_NotificationsNotificationId_Request_Body} - Request body type
  */
-export type DELETE_NotificationsNotificationId_V1_Request = {
+export type DELETE_NotificationsNotificationId_Request = {
   parameters: {
     path: operations['delete_notification_v1_notifications__notification_id__delete']['parameters']['path'];
   };
@@ -2264,7 +2264,7 @@ export type DELETE_NotificationsNotificationId_V1_Request = {
  *
  * @path /v1/notifications/{notification_id}
  */
-export type DELETE_NotificationsNotificationId_V1_Request_Parameters_Path = DELETE_NotificationsNotificationId_V1_Request['parameters']['path'];
+export type DELETE_NotificationsNotificationId_Request_Path = DELETE_NotificationsNotificationId_Request['parameters']['path'];
 
 /**
  * Request type for GET NotificationsNotificationId endpoint
@@ -2281,11 +2281,11 @@ export type DELETE_NotificationsNotificationId_V1_Request_Parameters_Path = DELE
  *
  * @path /v1/notifications/{notification_id}
  *
- * @see {@link GET_NotificationsNotificationId_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_NotificationsNotificationId_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_NotificationsNotificationId_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_NotificationsNotificationId_Request_Query} - Query parameters type
+ * @see {@link GET_NotificationsNotificationId_Request_Path} - Path parameters type
+ * @see {@link GET_NotificationsNotificationId_Request_Body} - Request body type
  */
-export type GET_NotificationsNotificationId_V1_Request = {
+export type GET_NotificationsNotificationId_Request = {
   parameters: {
     query: operations['get_notification_v1_notifications__notification_id__get']['parameters']['query'];
     path: operations['get_notification_v1_notifications__notification_id__get']['parameters']['path'];
@@ -2303,7 +2303,7 @@ export type GET_NotificationsNotificationId_V1_Request = {
  *
  * @path /v1/notifications/{notification_id}
  */
-export type GET_NotificationsNotificationId_V1_Request_Parameters_Query = GET_NotificationsNotificationId_V1_Request['parameters']['query'];
+export type GET_NotificationsNotificationId_Request_Query = GET_NotificationsNotificationId_Request['parameters']['query'];
 /**
  * Path parameters for GET /v1/notifications/{notification_id}
  *
@@ -2316,7 +2316,7 @@ export type GET_NotificationsNotificationId_V1_Request_Parameters_Query = GET_No
  *
  * @path /v1/notifications/{notification_id}
  */
-export type GET_NotificationsNotificationId_V1_Request_Parameters_Path = GET_NotificationsNotificationId_V1_Request['parameters']['path'];
+export type GET_NotificationsNotificationId_Request_Path = GET_NotificationsNotificationId_Request['parameters']['path'];
 
 /**
  * Request type for PUT NotificationsNotificationId endpoint
@@ -2333,11 +2333,11 @@ export type GET_NotificationsNotificationId_V1_Request_Parameters_Path = GET_Not
  *
  * @path /v1/notifications/{notification_id}
  *
- * @see {@link PUT_NotificationsNotificationId_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link PUT_NotificationsNotificationId_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link PUT_NotificationsNotificationId_V1_Request_RequestBody} - Request body type
+ * @see {@link PUT_NotificationsNotificationId_Request_Query} - Query parameters type
+ * @see {@link PUT_NotificationsNotificationId_Request_Path} - Path parameters type
+ * @see {@link PUT_NotificationsNotificationId_Request_Body} - Request body type
  */
-export type PUT_NotificationsNotificationId_V1_Request = {
+export type PUT_NotificationsNotificationId_Request = {
   parameters: {
     path: operations['update_notification_v1_notifications__notification_id__put']['parameters']['path'];
   };
@@ -2355,7 +2355,7 @@ export type PUT_NotificationsNotificationId_V1_Request = {
  *
  * @path /v1/notifications/{notification_id}
  */
-export type PUT_NotificationsNotificationId_V1_Request_Parameters_Path = PUT_NotificationsNotificationId_V1_Request['parameters']['path'];
+export type PUT_NotificationsNotificationId_Request_Path = PUT_NotificationsNotificationId_Request['parameters']['path'];
 /**
  * Request body for PUT /v1/notifications/{notification_id}
  *
@@ -2368,7 +2368,7 @@ export type PUT_NotificationsNotificationId_V1_Request_Parameters_Path = PUT_Not
  *
  * @path /v1/notifications/{notification_id}
  */
-export type PUT_NotificationsNotificationId_V1_Request_RequestBody = PUT_NotificationsNotificationId_V1_Request['requestBody'];
+export type PUT_NotificationsNotificationId_Request_Body = PUT_NotificationsNotificationId_Request['requestBody'];
 
 /**
  * Request type for PATCH NotificationsNotificationIdRead endpoint
@@ -2385,11 +2385,11 @@ export type PUT_NotificationsNotificationId_V1_Request_RequestBody = PUT_Notific
  *
  * @path /v1/notifications/{notification_id}/read
  *
- * @see {@link PATCH_NotificationsNotificationIdRead_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link PATCH_NotificationsNotificationIdRead_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link PATCH_NotificationsNotificationIdRead_V1_Request_RequestBody} - Request body type
+ * @see {@link PATCH_NotificationsNotificationIdRead_Request_Query} - Query parameters type
+ * @see {@link PATCH_NotificationsNotificationIdRead_Request_Path} - Path parameters type
+ * @see {@link PATCH_NotificationsNotificationIdRead_Request_Body} - Request body type
  */
-export type PATCH_NotificationsNotificationIdRead_V1_Request = {
+export type PATCH_NotificationsNotificationIdRead_Request = {
   parameters: {
     path: operations['update_notification_read_v1_notifications__notification_id__read_patch']['parameters']['path'];
   };
@@ -2406,7 +2406,7 @@ export type PATCH_NotificationsNotificationIdRead_V1_Request = {
  *
  * @path /v1/notifications/{notification_id}/read
  */
-export type PATCH_NotificationsNotificationIdRead_V1_Request_Parameters_Path = PATCH_NotificationsNotificationIdRead_V1_Request['parameters']['path'];
+export type PATCH_NotificationsNotificationIdRead_Request_Path = PATCH_NotificationsNotificationIdRead_Request['parameters']['path'];
 
 /**
  * Request type for GET Organizations endpoint
@@ -2423,11 +2423,11 @@ export type PATCH_NotificationsNotificationIdRead_V1_Request_Parameters_Path = P
  *
  * @path /v1/organizations
  *
- * @see {@link GET_Organizations_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_Organizations_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_Organizations_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_Organizations_Request_Query} - Query parameters type
+ * @see {@link GET_Organizations_Request_Path} - Path parameters type
+ * @see {@link GET_Organizations_Request_Body} - Request body type
  */
-export type GET_Organizations_V1_Request = {
+export type GET_Organizations_Request = {
   parameters: {
     query: operations['list_organizations_v1_organizations_get']['parameters']['query'];
   };
@@ -2444,7 +2444,7 @@ export type GET_Organizations_V1_Request = {
  *
  * @path /v1/organizations
  */
-export type GET_Organizations_V1_Request_Parameters_Query = GET_Organizations_V1_Request['parameters']['query'];
+export type GET_Organizations_Request_Query = GET_Organizations_Request['parameters']['query'];
 
 /**
  * Request type for POST Organizations endpoint
@@ -2461,11 +2461,11 @@ export type GET_Organizations_V1_Request_Parameters_Query = GET_Organizations_V1
  *
  * @path /v1/organizations
  *
- * @see {@link POST_Organizations_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link POST_Organizations_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link POST_Organizations_V1_Request_RequestBody} - Request body type
+ * @see {@link POST_Organizations_Request_Query} - Query parameters type
+ * @see {@link POST_Organizations_Request_Path} - Path parameters type
+ * @see {@link POST_Organizations_Request_Body} - Request body type
  */
-export type POST_Organizations_V1_Request = {
+export type POST_Organizations_Request = {
   requestBody: OrganizationCreate;
 }
 /**
@@ -2480,7 +2480,7 @@ export type POST_Organizations_V1_Request = {
  *
  * @path /v1/organizations
  */
-export type POST_Organizations_V1_Request_RequestBody = POST_Organizations_V1_Request['requestBody'];
+export type POST_Organizations_Request_Body = POST_Organizations_Request['requestBody'];
 
 /**
  * Request type for GET OrganizationsAttributes endpoint
@@ -2498,11 +2498,11 @@ export type POST_Organizations_V1_Request_RequestBody = POST_Organizations_V1_Re
  * @path /v1/organizations/attributes
  * @param keys (query) - Optional list of attribute keys to filter
  *
- * @see {@link GET_OrganizationsAttributes_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_OrganizationsAttributes_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_OrganizationsAttributes_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_OrganizationsAttributes_Request_Query} - Query parameters type
+ * @see {@link GET_OrganizationsAttributes_Request_Path} - Path parameters type
+ * @see {@link GET_OrganizationsAttributes_Request_Body} - Request body type
  */
-export type GET_OrganizationsAttributes_V1_Request = {
+export type GET_OrganizationsAttributes_Request = {
   parameters: {
     query: operations['get_attributes_v1_organizations_attributes_get']['parameters']['query'];
   };
@@ -2520,7 +2520,7 @@ export type GET_OrganizationsAttributes_V1_Request = {
  * @path /v1/organizations/attributes
  * @param keys (query) - Optional list of attribute keys to filter
  */
-export type GET_OrganizationsAttributes_V1_Request_Parameters_Query = GET_OrganizationsAttributes_V1_Request['parameters']['query'];
+export type GET_OrganizationsAttributes_Request_Query = GET_OrganizationsAttributes_Request['parameters']['query'];
 
 /**
  * Request type for PATCH OrganizationsAttributes endpoint
@@ -2537,11 +2537,11 @@ export type GET_OrganizationsAttributes_V1_Request_Parameters_Query = GET_Organi
  *
  * @path /v1/organizations/attributes
  *
- * @see {@link PATCH_OrganizationsAttributes_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link PATCH_OrganizationsAttributes_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link PATCH_OrganizationsAttributes_V1_Request_RequestBody} - Request body type
+ * @see {@link PATCH_OrganizationsAttributes_Request_Query} - Query parameters type
+ * @see {@link PATCH_OrganizationsAttributes_Request_Path} - Path parameters type
+ * @see {@link PATCH_OrganizationsAttributes_Request_Body} - Request body type
  */
-export type PATCH_OrganizationsAttributes_V1_Request = {
+export type PATCH_OrganizationsAttributes_Request = {
   parameters: {
     query: operations['update_attributes_v1_organizations_attributes_patch']['parameters']['query'];
   };
@@ -2559,7 +2559,7 @@ export type PATCH_OrganizationsAttributes_V1_Request = {
  *
  * @path /v1/organizations/attributes
  */
-export type PATCH_OrganizationsAttributes_V1_Request_Parameters_Query = PATCH_OrganizationsAttributes_V1_Request['parameters']['query'];
+export type PATCH_OrganizationsAttributes_Request_Query = PATCH_OrganizationsAttributes_Request['parameters']['query'];
 /**
  * Request body for PATCH /v1/organizations/attributes
  *
@@ -2572,7 +2572,7 @@ export type PATCH_OrganizationsAttributes_V1_Request_Parameters_Query = PATCH_Or
  *
  * @path /v1/organizations/attributes
  */
-export type PATCH_OrganizationsAttributes_V1_Request_RequestBody = PATCH_OrganizationsAttributes_V1_Request['requestBody'];
+export type PATCH_OrganizationsAttributes_Request_Body = PATCH_OrganizationsAttributes_Request['requestBody'];
 
 /**
  * Request type for GET OrganizationsAttributesOrganizationId endpoint
@@ -2590,11 +2590,11 @@ export type PATCH_OrganizationsAttributes_V1_Request_RequestBody = PATCH_Organiz
  * @path /v1/organizations/attributes/{organization_id}
  * @param keys (query) - Optional list of attribute keys to filter
  *
- * @see {@link GET_OrganizationsAttributesOrganizationId_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_OrganizationsAttributesOrganizationId_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_OrganizationsAttributesOrganizationId_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_OrganizationsAttributesOrganizationId_Request_Query} - Query parameters type
+ * @see {@link GET_OrganizationsAttributesOrganizationId_Request_Path} - Path parameters type
+ * @see {@link GET_OrganizationsAttributesOrganizationId_Request_Body} - Request body type
  */
-export type GET_OrganizationsAttributesOrganizationId_V1_Request = {
+export type GET_OrganizationsAttributesOrganizationId_Request = {
   parameters: {
     query: operations['get_attributes_v1_organizations_attributes__organization_id__get']['parameters']['query'];
     path: operations['get_attributes_v1_organizations_attributes__organization_id__get']['parameters']['path'];
@@ -2613,7 +2613,7 @@ export type GET_OrganizationsAttributesOrganizationId_V1_Request = {
  * @path /v1/organizations/attributes/{organization_id}
  * @param keys (query) - Optional list of attribute keys to filter
  */
-export type GET_OrganizationsAttributesOrganizationId_V1_Request_Parameters_Query = GET_OrganizationsAttributesOrganizationId_V1_Request['parameters']['query'];
+export type GET_OrganizationsAttributesOrganizationId_Request_Query = GET_OrganizationsAttributesOrganizationId_Request['parameters']['query'];
 /**
  * Path parameters for GET /v1/organizations/attributes/{organization_id}
  *
@@ -2626,7 +2626,7 @@ export type GET_OrganizationsAttributesOrganizationId_V1_Request_Parameters_Quer
  *
  * @path /v1/organizations/attributes/{organization_id}
  */
-export type GET_OrganizationsAttributesOrganizationId_V1_Request_Parameters_Path = GET_OrganizationsAttributesOrganizationId_V1_Request['parameters']['path'];
+export type GET_OrganizationsAttributesOrganizationId_Request_Path = GET_OrganizationsAttributesOrganizationId_Request['parameters']['path'];
 
 /**
  * Request type for PATCH OrganizationsAttributesOrganizationId endpoint
@@ -2643,11 +2643,11 @@ export type GET_OrganizationsAttributesOrganizationId_V1_Request_Parameters_Path
  *
  * @path /v1/organizations/attributes/{organization_id}
  *
- * @see {@link PATCH_OrganizationsAttributesOrganizationId_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link PATCH_OrganizationsAttributesOrganizationId_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link PATCH_OrganizationsAttributesOrganizationId_V1_Request_RequestBody} - Request body type
+ * @see {@link PATCH_OrganizationsAttributesOrganizationId_Request_Query} - Query parameters type
+ * @see {@link PATCH_OrganizationsAttributesOrganizationId_Request_Path} - Path parameters type
+ * @see {@link PATCH_OrganizationsAttributesOrganizationId_Request_Body} - Request body type
  */
-export type PATCH_OrganizationsAttributesOrganizationId_V1_Request = {
+export type PATCH_OrganizationsAttributesOrganizationId_Request = {
   parameters: {
     path: operations['update_attributes_v1_organizations_attributes__organization_id__patch']['parameters']['path'];
   };
@@ -2665,7 +2665,7 @@ export type PATCH_OrganizationsAttributesOrganizationId_V1_Request = {
  *
  * @path /v1/organizations/attributes/{organization_id}
  */
-export type PATCH_OrganizationsAttributesOrganizationId_V1_Request_Parameters_Path = PATCH_OrganizationsAttributesOrganizationId_V1_Request['parameters']['path'];
+export type PATCH_OrganizationsAttributesOrganizationId_Request_Path = PATCH_OrganizationsAttributesOrganizationId_Request['parameters']['path'];
 /**
  * Request body for PATCH /v1/organizations/attributes/{organization_id}
  *
@@ -2678,7 +2678,7 @@ export type PATCH_OrganizationsAttributesOrganizationId_V1_Request_Parameters_Pa
  *
  * @path /v1/organizations/attributes/{organization_id}
  */
-export type PATCH_OrganizationsAttributesOrganizationId_V1_Request_RequestBody = PATCH_OrganizationsAttributesOrganizationId_V1_Request['requestBody'];
+export type PATCH_OrganizationsAttributesOrganizationId_Request_Body = PATCH_OrganizationsAttributesOrganizationId_Request['requestBody'];
 
 /**
  * Request type for GET OrganizationsIpRestrictions endpoint
@@ -2696,11 +2696,11 @@ export type PATCH_OrganizationsAttributesOrganizationId_V1_Request_RequestBody =
  *
  * @path /v1/organizations/ip-restrictions
  *
- * @see {@link GET_OrganizationsIpRestrictions_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_OrganizationsIpRestrictions_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_OrganizationsIpRestrictions_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_OrganizationsIpRestrictions_Request_Query} - Query parameters type
+ * @see {@link GET_OrganizationsIpRestrictions_Request_Path} - Path parameters type
+ * @see {@link GET_OrganizationsIpRestrictions_Request_Body} - Request body type
  */
-export type GET_OrganizationsIpRestrictions_V1_Request = {
+export type GET_OrganizationsIpRestrictions_Request = {
 }
 
 /**
@@ -2719,11 +2719,11 @@ export type GET_OrganizationsIpRestrictions_V1_Request = {
  *
  * @path /v1/organizations/ip-restrictions
  *
- * @see {@link POST_OrganizationsIpRestrictions_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link POST_OrganizationsIpRestrictions_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link POST_OrganizationsIpRestrictions_V1_Request_RequestBody} - Request body type
+ * @see {@link POST_OrganizationsIpRestrictions_Request_Query} - Query parameters type
+ * @see {@link POST_OrganizationsIpRestrictions_Request_Path} - Path parameters type
+ * @see {@link POST_OrganizationsIpRestrictions_Request_Body} - Request body type
  */
-export type POST_OrganizationsIpRestrictions_V1_Request = {
+export type POST_OrganizationsIpRestrictions_Request = {
   requestBody: IpRestrictionCreate;
 }
 /**
@@ -2738,7 +2738,7 @@ export type POST_OrganizationsIpRestrictions_V1_Request = {
  *
  * @path /v1/organizations/ip-restrictions
  */
-export type POST_OrganizationsIpRestrictions_V1_Request_RequestBody = POST_OrganizationsIpRestrictions_V1_Request['requestBody'];
+export type POST_OrganizationsIpRestrictions_Request_Body = POST_OrganizationsIpRestrictions_Request['requestBody'];
 
 /**
  * Request type for DELETE OrganizationsIpRestrictionsIpRestrictionId endpoint
@@ -2756,11 +2756,11 @@ export type POST_OrganizationsIpRestrictions_V1_Request_RequestBody = POST_Organ
  *
  * @path /v1/organizations/ip-restrictions/{ip_restriction_id}
  *
- * @see {@link DELETE_OrganizationsIpRestrictionsIpRestrictionId_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link DELETE_OrganizationsIpRestrictionsIpRestrictionId_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link DELETE_OrganizationsIpRestrictionsIpRestrictionId_V1_Request_RequestBody} - Request body type
+ * @see {@link DELETE_OrganizationsIpRestrictionsIpRestrictionId_Request_Query} - Query parameters type
+ * @see {@link DELETE_OrganizationsIpRestrictionsIpRestrictionId_Request_Path} - Path parameters type
+ * @see {@link DELETE_OrganizationsIpRestrictionsIpRestrictionId_Request_Body} - Request body type
  */
-export type DELETE_OrganizationsIpRestrictionsIpRestrictionId_V1_Request = {
+export type DELETE_OrganizationsIpRestrictionsIpRestrictionId_Request = {
   parameters: {
     path: operations['delete_ip_restriction_v1_organizations_ip_restrictions__ip_restriction_id__delete']['parameters']['path'];
   };
@@ -2777,7 +2777,7 @@ export type DELETE_OrganizationsIpRestrictionsIpRestrictionId_V1_Request = {
  *
  * @path /v1/organizations/ip-restrictions/{ip_restriction_id}
  */
-export type DELETE_OrganizationsIpRestrictionsIpRestrictionId_V1_Request_Parameters_Path = DELETE_OrganizationsIpRestrictionsIpRestrictionId_V1_Request['parameters']['path'];
+export type DELETE_OrganizationsIpRestrictionsIpRestrictionId_Request_Path = DELETE_OrganizationsIpRestrictionsIpRestrictionId_Request['parameters']['path'];
 
 /**
  * Request type for GET OrganizationsIpRestrictionsIpRestrictionId endpoint
@@ -2795,11 +2795,11 @@ export type DELETE_OrganizationsIpRestrictionsIpRestrictionId_V1_Request_Paramet
  *
  * @path /v1/organizations/ip-restrictions/{ip_restriction_id}
  *
- * @see {@link GET_OrganizationsIpRestrictionsIpRestrictionId_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_OrganizationsIpRestrictionsIpRestrictionId_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_OrganizationsIpRestrictionsIpRestrictionId_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_OrganizationsIpRestrictionsIpRestrictionId_Request_Query} - Query parameters type
+ * @see {@link GET_OrganizationsIpRestrictionsIpRestrictionId_Request_Path} - Path parameters type
+ * @see {@link GET_OrganizationsIpRestrictionsIpRestrictionId_Request_Body} - Request body type
  */
-export type GET_OrganizationsIpRestrictionsIpRestrictionId_V1_Request = {
+export type GET_OrganizationsIpRestrictionsIpRestrictionId_Request = {
   parameters: {
     path: operations['get_ip_restriction_v1_organizations_ip_restrictions__ip_restriction_id__get']['parameters']['path'];
   };
@@ -2816,7 +2816,7 @@ export type GET_OrganizationsIpRestrictionsIpRestrictionId_V1_Request = {
  *
  * @path /v1/organizations/ip-restrictions/{ip_restriction_id}
  */
-export type GET_OrganizationsIpRestrictionsIpRestrictionId_V1_Request_Parameters_Path = GET_OrganizationsIpRestrictionsIpRestrictionId_V1_Request['parameters']['path'];
+export type GET_OrganizationsIpRestrictionsIpRestrictionId_Request_Path = GET_OrganizationsIpRestrictionsIpRestrictionId_Request['parameters']['path'];
 
 /**
  * Request type for PATCH OrganizationsIpRestrictionsIpRestrictionId endpoint
@@ -2834,11 +2834,11 @@ export type GET_OrganizationsIpRestrictionsIpRestrictionId_V1_Request_Parameters
  *
  * @path /v1/organizations/ip-restrictions/{ip_restriction_id}
  *
- * @see {@link PATCH_OrganizationsIpRestrictionsIpRestrictionId_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link PATCH_OrganizationsIpRestrictionsIpRestrictionId_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link PATCH_OrganizationsIpRestrictionsIpRestrictionId_V1_Request_RequestBody} - Request body type
+ * @see {@link PATCH_OrganizationsIpRestrictionsIpRestrictionId_Request_Query} - Query parameters type
+ * @see {@link PATCH_OrganizationsIpRestrictionsIpRestrictionId_Request_Path} - Path parameters type
+ * @see {@link PATCH_OrganizationsIpRestrictionsIpRestrictionId_Request_Body} - Request body type
  */
-export type PATCH_OrganizationsIpRestrictionsIpRestrictionId_V1_Request = {
+export type PATCH_OrganizationsIpRestrictionsIpRestrictionId_Request = {
   parameters: {
     path: operations['update_ip_restriction_v1_organizations_ip_restrictions__ip_restriction_id__patch']['parameters']['path'];
   };
@@ -2856,7 +2856,7 @@ export type PATCH_OrganizationsIpRestrictionsIpRestrictionId_V1_Request = {
  *
  * @path /v1/organizations/ip-restrictions/{ip_restriction_id}
  */
-export type PATCH_OrganizationsIpRestrictionsIpRestrictionId_V1_Request_Parameters_Path = PATCH_OrganizationsIpRestrictionsIpRestrictionId_V1_Request['parameters']['path'];
+export type PATCH_OrganizationsIpRestrictionsIpRestrictionId_Request_Path = PATCH_OrganizationsIpRestrictionsIpRestrictionId_Request['parameters']['path'];
 /**
  * Request body for PATCH /v1/organizations/ip-restrictions/{ip_restriction_id}
  *
@@ -2869,7 +2869,7 @@ export type PATCH_OrganizationsIpRestrictionsIpRestrictionId_V1_Request_Paramete
  *
  * @path /v1/organizations/ip-restrictions/{ip_restriction_id}
  */
-export type PATCH_OrganizationsIpRestrictionsIpRestrictionId_V1_Request_RequestBody = PATCH_OrganizationsIpRestrictionsIpRestrictionId_V1_Request['requestBody'];
+export type PATCH_OrganizationsIpRestrictionsIpRestrictionId_Request_Body = PATCH_OrganizationsIpRestrictionsIpRestrictionId_Request['requestBody'];
 
 /**
  * Request type for DELETE OrganizationsOrganizationId endpoint
@@ -2886,11 +2886,11 @@ export type PATCH_OrganizationsIpRestrictionsIpRestrictionId_V1_Request_RequestB
  *
  * @path /v1/organizations/{organization_id}
  *
- * @see {@link DELETE_OrganizationsOrganizationId_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link DELETE_OrganizationsOrganizationId_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link DELETE_OrganizationsOrganizationId_V1_Request_RequestBody} - Request body type
+ * @see {@link DELETE_OrganizationsOrganizationId_Request_Query} - Query parameters type
+ * @see {@link DELETE_OrganizationsOrganizationId_Request_Path} - Path parameters type
+ * @see {@link DELETE_OrganizationsOrganizationId_Request_Body} - Request body type
  */
-export type DELETE_OrganizationsOrganizationId_V1_Request = {
+export type DELETE_OrganizationsOrganizationId_Request = {
   parameters: {
     path: operations['delete_user_v1_organizations__organization_id__delete']['parameters']['path'];
   };
@@ -2907,7 +2907,7 @@ export type DELETE_OrganizationsOrganizationId_V1_Request = {
  *
  * @path /v1/organizations/{organization_id}
  */
-export type DELETE_OrganizationsOrganizationId_V1_Request_Parameters_Path = DELETE_OrganizationsOrganizationId_V1_Request['parameters']['path'];
+export type DELETE_OrganizationsOrganizationId_Request_Path = DELETE_OrganizationsOrganizationId_Request['parameters']['path'];
 
 /**
  * Request type for GET OrganizationsOrganizationId endpoint
@@ -2924,11 +2924,11 @@ export type DELETE_OrganizationsOrganizationId_V1_Request_Parameters_Path = DELE
  *
  * @path /v1/organizations/{organization_id}
  *
- * @see {@link GET_OrganizationsOrganizationId_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_OrganizationsOrganizationId_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_OrganizationsOrganizationId_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_OrganizationsOrganizationId_Request_Query} - Query parameters type
+ * @see {@link GET_OrganizationsOrganizationId_Request_Path} - Path parameters type
+ * @see {@link GET_OrganizationsOrganizationId_Request_Body} - Request body type
  */
-export type GET_OrganizationsOrganizationId_V1_Request = {
+export type GET_OrganizationsOrganizationId_Request = {
   parameters: {
     path: operations['get_organization_v1_organizations__organization_id__get']['parameters']['path'];
   };
@@ -2945,7 +2945,7 @@ export type GET_OrganizationsOrganizationId_V1_Request = {
  *
  * @path /v1/organizations/{organization_id}
  */
-export type GET_OrganizationsOrganizationId_V1_Request_Parameters_Path = GET_OrganizationsOrganizationId_V1_Request['parameters']['path'];
+export type GET_OrganizationsOrganizationId_Request_Path = GET_OrganizationsOrganizationId_Request['parameters']['path'];
 
 /**
  * Request type for PATCH OrganizationsOrganizationId endpoint
@@ -2962,11 +2962,11 @@ export type GET_OrganizationsOrganizationId_V1_Request_Parameters_Path = GET_Org
  *
  * @path /v1/organizations/{organization_id}
  *
- * @see {@link PATCH_OrganizationsOrganizationId_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link PATCH_OrganizationsOrganizationId_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link PATCH_OrganizationsOrganizationId_V1_Request_RequestBody} - Request body type
+ * @see {@link PATCH_OrganizationsOrganizationId_Request_Query} - Query parameters type
+ * @see {@link PATCH_OrganizationsOrganizationId_Request_Path} - Path parameters type
+ * @see {@link PATCH_OrganizationsOrganizationId_Request_Body} - Request body type
  */
-export type PATCH_OrganizationsOrganizationId_V1_Request = {
+export type PATCH_OrganizationsOrganizationId_Request = {
   parameters: {
     path: operations['update_organization_v1_organizations__organization_id__patch']['parameters']['path'];
   };
@@ -2984,7 +2984,7 @@ export type PATCH_OrganizationsOrganizationId_V1_Request = {
  *
  * @path /v1/organizations/{organization_id}
  */
-export type PATCH_OrganizationsOrganizationId_V1_Request_Parameters_Path = PATCH_OrganizationsOrganizationId_V1_Request['parameters']['path'];
+export type PATCH_OrganizationsOrganizationId_Request_Path = PATCH_OrganizationsOrganizationId_Request['parameters']['path'];
 /**
  * Request body for PATCH /v1/organizations/{organization_id}
  *
@@ -2997,7 +2997,7 @@ export type PATCH_OrganizationsOrganizationId_V1_Request_Parameters_Path = PATCH
  *
  * @path /v1/organizations/{organization_id}
  */
-export type PATCH_OrganizationsOrganizationId_V1_Request_RequestBody = PATCH_OrganizationsOrganizationId_V1_Request['requestBody'];
+export type PATCH_OrganizationsOrganizationId_Request_Body = PATCH_OrganizationsOrganizationId_Request['requestBody'];
 
 /**
  * Request type for PATCH OrganizationsOrganizationIdPlan endpoint
@@ -3014,11 +3014,11 @@ export type PATCH_OrganizationsOrganizationId_V1_Request_RequestBody = PATCH_Org
  *
  * @path /v1/organizations/{organization_id}/plan
  *
- * @see {@link PATCH_OrganizationsOrganizationIdPlan_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link PATCH_OrganizationsOrganizationIdPlan_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link PATCH_OrganizationsOrganizationIdPlan_V1_Request_RequestBody} - Request body type
+ * @see {@link PATCH_OrganizationsOrganizationIdPlan_Request_Query} - Query parameters type
+ * @see {@link PATCH_OrganizationsOrganizationIdPlan_Request_Path} - Path parameters type
+ * @see {@link PATCH_OrganizationsOrganizationIdPlan_Request_Body} - Request body type
  */
-export type PATCH_OrganizationsOrganizationIdPlan_V1_Request = {
+export type PATCH_OrganizationsOrganizationIdPlan_Request = {
   parameters: {
     path: operations['change_plan_v1_organizations__organization_id__plan_patch']['parameters']['path'];
   };
@@ -3036,7 +3036,7 @@ export type PATCH_OrganizationsOrganizationIdPlan_V1_Request = {
  *
  * @path /v1/organizations/{organization_id}/plan
  */
-export type PATCH_OrganizationsOrganizationIdPlan_V1_Request_Parameters_Path = PATCH_OrganizationsOrganizationIdPlan_V1_Request['parameters']['path'];
+export type PATCH_OrganizationsOrganizationIdPlan_Request_Path = PATCH_OrganizationsOrganizationIdPlan_Request['parameters']['path'];
 /**
  * Request body for PATCH /v1/organizations/{organization_id}/plan
  *
@@ -3049,7 +3049,7 @@ export type PATCH_OrganizationsOrganizationIdPlan_V1_Request_Parameters_Path = P
  *
  * @path /v1/organizations/{organization_id}/plan
  */
-export type PATCH_OrganizationsOrganizationIdPlan_V1_Request_RequestBody = PATCH_OrganizationsOrganizationIdPlan_V1_Request['requestBody'];
+export type PATCH_OrganizationsOrganizationIdPlan_Request_Body = PATCH_OrganizationsOrganizationIdPlan_Request['requestBody'];
 
 /**
  * Request type for GET OrganizationsRoles endpoint
@@ -3066,11 +3066,11 @@ export type PATCH_OrganizationsOrganizationIdPlan_V1_Request_RequestBody = PATCH
  *
  * @path /v1/organizations/roles
  *
- * @see {@link GET_OrganizationsRoles_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_OrganizationsRoles_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_OrganizationsRoles_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_OrganizationsRoles_Request_Query} - Query parameters type
+ * @see {@link GET_OrganizationsRoles_Request_Path} - Path parameters type
+ * @see {@link GET_OrganizationsRoles_Request_Body} - Request body type
  */
-export type GET_OrganizationsRoles_V1_Request = {
+export type GET_OrganizationsRoles_Request = {
 }
 
 /**
@@ -3088,11 +3088,11 @@ export type GET_OrganizationsRoles_V1_Request = {
  *
  * @path /v1/organizations/users
  *
- * @see {@link GET_OrganizationsUsers_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_OrganizationsUsers_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_OrganizationsUsers_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_OrganizationsUsers_Request_Query} - Query parameters type
+ * @see {@link GET_OrganizationsUsers_Request_Path} - Path parameters type
+ * @see {@link GET_OrganizationsUsers_Request_Body} - Request body type
  */
-export type GET_OrganizationsUsers_V1_Request = {
+export type GET_OrganizationsUsers_Request = {
   parameters: {
     query: operations['list_users_v1_organizations_users_get']['parameters']['query'];
   };
@@ -3109,7 +3109,7 @@ export type GET_OrganizationsUsers_V1_Request = {
  *
  * @path /v1/organizations/users
  */
-export type GET_OrganizationsUsers_V1_Request_Parameters_Query = GET_OrganizationsUsers_V1_Request['parameters']['query'];
+export type GET_OrganizationsUsers_Request_Query = GET_OrganizationsUsers_Request['parameters']['query'];
 
 /**
  * Request type for POST Users endpoint
@@ -3126,11 +3126,11 @@ export type GET_OrganizationsUsers_V1_Request_Parameters_Query = GET_Organizatio
  *
  * @path /v1/users
  *
- * @see {@link POST_Users_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link POST_Users_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link POST_Users_V1_Request_RequestBody} - Request body type
+ * @see {@link POST_Users_Request_Query} - Query parameters type
+ * @see {@link POST_Users_Request_Path} - Path parameters type
+ * @see {@link POST_Users_Request_Body} - Request body type
  */
-export type POST_Users_V1_Request = {
+export type POST_Users_Request = {
   requestBody: UserCreate;
 }
 /**
@@ -3145,7 +3145,7 @@ export type POST_Users_V1_Request = {
  *
  * @path /v1/users
  */
-export type POST_Users_V1_Request_RequestBody = POST_Users_V1_Request['requestBody'];
+export type POST_Users_Request_Body = POST_Users_Request['requestBody'];
 
 /**
  * Request type for POST UsersAcceptTos endpoint
@@ -3162,11 +3162,11 @@ export type POST_Users_V1_Request_RequestBody = POST_Users_V1_Request['requestBo
  *
  * @path /v1/users/accept-tos
  *
- * @see {@link POST_UsersAcceptTos_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link POST_UsersAcceptTos_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link POST_UsersAcceptTos_V1_Request_RequestBody} - Request body type
+ * @see {@link POST_UsersAcceptTos_Request_Query} - Query parameters type
+ * @see {@link POST_UsersAcceptTos_Request_Path} - Path parameters type
+ * @see {@link POST_UsersAcceptTos_Request_Body} - Request body type
  */
-export type POST_UsersAcceptTos_V1_Request = {
+export type POST_UsersAcceptTos_Request = {
   requestBody: TermsOfServiceAccept;
 }
 /**
@@ -3181,7 +3181,7 @@ export type POST_UsersAcceptTos_V1_Request = {
  *
  * @path /v1/users/accept-tos
  */
-export type POST_UsersAcceptTos_V1_Request_RequestBody = POST_UsersAcceptTos_V1_Request['requestBody'];
+export type POST_UsersAcceptTos_Request_Body = POST_UsersAcceptTos_Request['requestBody'];
 
 /**
  * Request type for GET UsersMe endpoint
@@ -3198,11 +3198,11 @@ export type POST_UsersAcceptTos_V1_Request_RequestBody = POST_UsersAcceptTos_V1_
  *
  * @path /v1/users/me
  *
- * @see {@link GET_UsersMe_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_UsersMe_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_UsersMe_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_UsersMe_Request_Query} - Query parameters type
+ * @see {@link GET_UsersMe_Request_Path} - Path parameters type
+ * @see {@link GET_UsersMe_Request_Body} - Request body type
  */
-export type GET_UsersMe_V1_Request = {
+export type GET_UsersMe_Request = {
   parameters: {
     query: operations['get_current_user_v1_users_me_get']['parameters']['query'];
   };
@@ -3219,7 +3219,7 @@ export type GET_UsersMe_V1_Request = {
  *
  * @path /v1/users/me
  */
-export type GET_UsersMe_V1_Request_Parameters_Query = GET_UsersMe_V1_Request['parameters']['query'];
+export type GET_UsersMe_Request_Query = GET_UsersMe_Request['parameters']['query'];
 
 /**
  * Request type for DELETE UsersUserId endpoint
@@ -3236,11 +3236,11 @@ export type GET_UsersMe_V1_Request_Parameters_Query = GET_UsersMe_V1_Request['pa
  *
  * @path /v1/users/{user_id}
  *
- * @see {@link DELETE_UsersUserId_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link DELETE_UsersUserId_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link DELETE_UsersUserId_V1_Request_RequestBody} - Request body type
+ * @see {@link DELETE_UsersUserId_Request_Query} - Query parameters type
+ * @see {@link DELETE_UsersUserId_Request_Path} - Path parameters type
+ * @see {@link DELETE_UsersUserId_Request_Body} - Request body type
  */
-export type DELETE_UsersUserId_V1_Request = {
+export type DELETE_UsersUserId_Request = {
   parameters: {
     path: operations['delete_user_v1_users__user_id__delete']['parameters']['path'];
   };
@@ -3257,7 +3257,7 @@ export type DELETE_UsersUserId_V1_Request = {
  *
  * @path /v1/users/{user_id}
  */
-export type DELETE_UsersUserId_V1_Request_Parameters_Path = DELETE_UsersUserId_V1_Request['parameters']['path'];
+export type DELETE_UsersUserId_Request_Path = DELETE_UsersUserId_Request['parameters']['path'];
 
 /**
  * Request type for GET UsersUserId endpoint
@@ -3274,11 +3274,11 @@ export type DELETE_UsersUserId_V1_Request_Parameters_Path = DELETE_UsersUserId_V
  *
  * @path /v1/users/{user_id}
  *
- * @see {@link GET_UsersUserId_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_UsersUserId_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_UsersUserId_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_UsersUserId_Request_Query} - Query parameters type
+ * @see {@link GET_UsersUserId_Request_Path} - Path parameters type
+ * @see {@link GET_UsersUserId_Request_Body} - Request body type
  */
-export type GET_UsersUserId_V1_Request = {
+export type GET_UsersUserId_Request = {
   parameters: {
     query: operations['get_user_v1_users__user_id__get']['parameters']['query'];
     path: operations['get_user_v1_users__user_id__get']['parameters']['path'];
@@ -3296,7 +3296,7 @@ export type GET_UsersUserId_V1_Request = {
  *
  * @path /v1/users/{user_id}
  */
-export type GET_UsersUserId_V1_Request_Parameters_Query = GET_UsersUserId_V1_Request['parameters']['query'];
+export type GET_UsersUserId_Request_Query = GET_UsersUserId_Request['parameters']['query'];
 /**
  * Path parameters for GET /v1/users/{user_id}
  *
@@ -3309,7 +3309,7 @@ export type GET_UsersUserId_V1_Request_Parameters_Query = GET_UsersUserId_V1_Req
  *
  * @path /v1/users/{user_id}
  */
-export type GET_UsersUserId_V1_Request_Parameters_Path = GET_UsersUserId_V1_Request['parameters']['path'];
+export type GET_UsersUserId_Request_Path = GET_UsersUserId_Request['parameters']['path'];
 
 /**
  * Request type for PATCH UsersUserId endpoint
@@ -3326,11 +3326,11 @@ export type GET_UsersUserId_V1_Request_Parameters_Path = GET_UsersUserId_V1_Requ
  *
  * @path /v1/users/{user_id}
  *
- * @see {@link PATCH_UsersUserId_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link PATCH_UsersUserId_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link PATCH_UsersUserId_V1_Request_RequestBody} - Request body type
+ * @see {@link PATCH_UsersUserId_Request_Query} - Query parameters type
+ * @see {@link PATCH_UsersUserId_Request_Path} - Path parameters type
+ * @see {@link PATCH_UsersUserId_Request_Body} - Request body type
  */
-export type PATCH_UsersUserId_V1_Request = {
+export type PATCH_UsersUserId_Request = {
   parameters: {
     path: operations['update_user_v1_users__user_id__patch']['parameters']['path'];
   };
@@ -3348,7 +3348,7 @@ export type PATCH_UsersUserId_V1_Request = {
  *
  * @path /v1/users/{user_id}
  */
-export type PATCH_UsersUserId_V1_Request_Parameters_Path = PATCH_UsersUserId_V1_Request['parameters']['path'];
+export type PATCH_UsersUserId_Request_Path = PATCH_UsersUserId_Request['parameters']['path'];
 /**
  * Request body for PATCH /v1/users/{user_id}
  *
@@ -3361,7 +3361,7 @@ export type PATCH_UsersUserId_V1_Request_Parameters_Path = PATCH_UsersUserId_V1_
  *
  * @path /v1/users/{user_id}
  */
-export type PATCH_UsersUserId_V1_Request_RequestBody = PATCH_UsersUserId_V1_Request['requestBody'];
+export type PATCH_UsersUserId_Request_Body = PATCH_UsersUserId_Request['requestBody'];
 
 /**
  * Request type for GET UsersUserIdPermissions endpoint
@@ -3378,11 +3378,11 @@ export type PATCH_UsersUserId_V1_Request_RequestBody = PATCH_UsersUserId_V1_Requ
  *
  * @path /v1/users/{user_id}/permissions
  *
- * @see {@link GET_UsersUserIdPermissions_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_UsersUserIdPermissions_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_UsersUserIdPermissions_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_UsersUserIdPermissions_Request_Query} - Query parameters type
+ * @see {@link GET_UsersUserIdPermissions_Request_Path} - Path parameters type
+ * @see {@link GET_UsersUserIdPermissions_Request_Body} - Request body type
  */
-export type GET_UsersUserIdPermissions_V1_Request = {
+export type GET_UsersUserIdPermissions_Request = {
   parameters: {
     path: operations['get_user_permissions_v1_users__user_id__permissions_get']['parameters']['path'];
   };
@@ -3399,7 +3399,7 @@ export type GET_UsersUserIdPermissions_V1_Request = {
  *
  * @path /v1/users/{user_id}/permissions
  */
-export type GET_UsersUserIdPermissions_V1_Request_Parameters_Path = GET_UsersUserIdPermissions_V1_Request['parameters']['path'];
+export type GET_UsersUserIdPermissions_Request_Path = GET_UsersUserIdPermissions_Request['parameters']['path'];
 
 /**
  * Request type for GET UsersUserIdRoles endpoint
@@ -3416,11 +3416,11 @@ export type GET_UsersUserIdPermissions_V1_Request_Parameters_Path = GET_UsersUse
  *
  * @path /v1/users/{user_id}/roles
  *
- * @see {@link GET_UsersUserIdRoles_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link GET_UsersUserIdRoles_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link GET_UsersUserIdRoles_V1_Request_RequestBody} - Request body type
+ * @see {@link GET_UsersUserIdRoles_Request_Query} - Query parameters type
+ * @see {@link GET_UsersUserIdRoles_Request_Path} - Path parameters type
+ * @see {@link GET_UsersUserIdRoles_Request_Body} - Request body type
  */
-export type GET_UsersUserIdRoles_V1_Request = {
+export type GET_UsersUserIdRoles_Request = {
   parameters: {
     path: operations['list_roles_v1_users__user_id__roles_get']['parameters']['path'];
   };
@@ -3437,7 +3437,7 @@ export type GET_UsersUserIdRoles_V1_Request = {
  *
  * @path /v1/users/{user_id}/roles
  */
-export type GET_UsersUserIdRoles_V1_Request_Parameters_Path = GET_UsersUserIdRoles_V1_Request['parameters']['path'];
+export type GET_UsersUserIdRoles_Request_Path = GET_UsersUserIdRoles_Request['parameters']['path'];
 
 /**
  * Request type for PATCH UsersUserIdRoles endpoint
@@ -3454,11 +3454,11 @@ export type GET_UsersUserIdRoles_V1_Request_Parameters_Path = GET_UsersUserIdRol
  *
  * @path /v1/users/{user_id}/roles
  *
- * @see {@link PATCH_UsersUserIdRoles_V1_Request_Parameters_Query} - Query parameters type
- * @see {@link PATCH_UsersUserIdRoles_V1_Request_Parameters_Path} - Path parameters type
- * @see {@link PATCH_UsersUserIdRoles_V1_Request_RequestBody} - Request body type
+ * @see {@link PATCH_UsersUserIdRoles_Request_Query} - Query parameters type
+ * @see {@link PATCH_UsersUserIdRoles_Request_Path} - Path parameters type
+ * @see {@link PATCH_UsersUserIdRoles_Request_Body} - Request body type
  */
-export type PATCH_UsersUserIdRoles_V1_Request = {
+export type PATCH_UsersUserIdRoles_Request = {
   parameters: {
     path: operations['update_user_relations_v1_users__user_id__roles_patch']['parameters']['path'];
   };
@@ -3476,7 +3476,7 @@ export type PATCH_UsersUserIdRoles_V1_Request = {
  *
  * @path /v1/users/{user_id}/roles
  */
-export type PATCH_UsersUserIdRoles_V1_Request_Parameters_Path = PATCH_UsersUserIdRoles_V1_Request['parameters']['path'];
+export type PATCH_UsersUserIdRoles_Request_Path = PATCH_UsersUserIdRoles_Request['parameters']['path'];
 /**
  * Request body for PATCH /v1/users/{user_id}/roles
  *
@@ -3489,5 +3489,5 @@ export type PATCH_UsersUserIdRoles_V1_Request_Parameters_Path = PATCH_UsersUserI
  *
  * @path /v1/users/{user_id}/roles
  */
-export type PATCH_UsersUserIdRoles_V1_Request_RequestBody = PATCH_UsersUserIdRoles_V1_Request['requestBody'];
+export type PATCH_UsersUserIdRoles_Request_Body = PATCH_UsersUserIdRoles_Request['requestBody'];
 

--- a/src/helpers/responses.ts
+++ b/src/helpers/responses.ts
@@ -4638,7 +4638,7 @@ export type PATCH_OrganizationsIpRestrictionsByIpRestrictionId_Response_422 = HT
  *
 
  */
-export type GET_OrganizationsRoles_Response = never;
+export type GET_OrganizationsRoles_Response = unknown;
 
 /**
  * Response types for GET OrganizationsUsers endpoint

--- a/src/helpers/responses.ts
+++ b/src/helpers/responses.ts
@@ -30,7 +30,7 @@
  * Do not edit manually.
  */
 
-import { components } from '../schema';
+
 
 import { DomainDnssecDataArray, OrganizationAttribute2Array, IpRestrictionArray } from './schemas-arrays';
 

--- a/src/helpers/responses.ts
+++ b/src/helpers/responses.ts
@@ -4638,7 +4638,7 @@ export type PATCH_OrganizationsIpRestrictionsByIpRestrictionId_Response_422 = HT
  *
 
  */
-export type GET_OrganizationsRoles_Response = ;
+export type GET_OrganizationsRoles_Response = never;
 
 /**
  * Response types for GET OrganizationsUsers endpoint

--- a/src/helpers/responses.ts
+++ b/src/helpers/responses.ts
@@ -57,11 +57,7 @@ import { Pagination_OrganizationCredential, Problem, HTTPValidationError, Organi
  *
 
  */
-export type GET_AuthClientCredentials = {
-  200: GET_AuthClientCredentials_Response_200
-  401: GET_AuthClientCredentials_Response_401
-  422: GET_AuthClientCredentials_Response_422
-}
+export type GET_AuthClientCredentials_Response = GET_AuthClientCredentials_Response_200 | GET_AuthClientCredentials_Response_401 | GET_AuthClientCredentials_Response_422;
 
 /**
  * 200 response for GET AuthClientCredentials endpoint
@@ -76,7 +72,7 @@ export type GET_AuthClientCredentials = {
  * @path /v1/auth/client_credentials
  * @param status (query) - Optional status to filter the results
  *
- * @see {@link GET_AuthClientCredentials} - The main response type definition
+ * @see {@link GET_AuthClientCredentials_Response} - The main response type definition
  * @see {@link Pagination_OrganizationCredential} - The actual schema type definition
  */
 export type GET_AuthClientCredentials_Response_200 = Pagination_OrganizationCredential
@@ -94,7 +90,7 @@ export type GET_AuthClientCredentials_Response_200 = Pagination_OrganizationCred
  * @path /v1/auth/client_credentials
  * @param status (query) - Optional status to filter the results
  *
- * @see {@link GET_AuthClientCredentials} - The main response type definition
+ * @see {@link GET_AuthClientCredentials_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type GET_AuthClientCredentials_Response_401 = Problem
@@ -112,7 +108,7 @@ export type GET_AuthClientCredentials_Response_401 = Problem
  * @path /v1/auth/client_credentials
  * @param status (query) - Optional status to filter the results
  *
- * @see {@link GET_AuthClientCredentials} - The main response type definition
+ * @see {@link GET_AuthClientCredentials_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type GET_AuthClientCredentials_Response_422 = HTTPValidationError
@@ -137,11 +133,7 @@ export type GET_AuthClientCredentials_Response_422 = HTTPValidationError
  *
 
  */
-export type POST_AuthClientCredentials = {
-  200: POST_AuthClientCredentials_Response_200
-  401: POST_AuthClientCredentials_Response_401
-  422: POST_AuthClientCredentials_Response_422
-}
+export type POST_AuthClientCredentials_Response = POST_AuthClientCredentials_Response_200 | POST_AuthClientCredentials_Response_401 | POST_AuthClientCredentials_Response_422;
 
 /**
  * 200 response for POST AuthClientCredentials endpoint
@@ -155,7 +147,7 @@ export type POST_AuthClientCredentials = {
  *
  * @path /v1/auth/client_credentials
  *
- * @see {@link POST_AuthClientCredentials} - The main response type definition
+ * @see {@link POST_AuthClientCredentials_Response} - The main response type definition
  * @see {@link OrganizationCredentialCreated} - The actual schema type definition
  */
 export type POST_AuthClientCredentials_Response_200 = OrganizationCredentialCreated
@@ -172,7 +164,7 @@ export type POST_AuthClientCredentials_Response_200 = OrganizationCredentialCrea
  *
  * @path /v1/auth/client_credentials
  *
- * @see {@link POST_AuthClientCredentials} - The main response type definition
+ * @see {@link POST_AuthClientCredentials_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type POST_AuthClientCredentials_Response_401 = Problem
@@ -189,7 +181,7 @@ export type POST_AuthClientCredentials_Response_401 = Problem
  *
  * @path /v1/auth/client_credentials
  *
- * @see {@link POST_AuthClientCredentials} - The main response type definition
+ * @see {@link POST_AuthClientCredentials_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type POST_AuthClientCredentials_Response_422 = HTTPValidationError
@@ -214,11 +206,7 @@ export type POST_AuthClientCredentials_Response_422 = HTTPValidationError
  *
 
  */
-export type DELETE_AuthClientCredentialsByApiKeyId = {
-  401: DELETE_AuthClientCredentialsByApiKeyId_Response_401
-  404: DELETE_AuthClientCredentialsByApiKeyId_Response_404
-  422: DELETE_AuthClientCredentialsByApiKeyId_Response_422
-}
+export type DELETE_AuthClientCredentialsByApiKeyId_Response = DELETE_AuthClientCredentialsByApiKeyId_Response_401 | DELETE_AuthClientCredentialsByApiKeyId_Response_404 | DELETE_AuthClientCredentialsByApiKeyId_Response_422;
 
 /**
  * 401 response for DELETE AuthClientCredentialsByApiKeyId endpoint
@@ -232,7 +220,7 @@ export type DELETE_AuthClientCredentialsByApiKeyId = {
  *
  * @path /v1/auth/client_credentials/{api_key_id}
  *
- * @see {@link DELETE_AuthClientCredentialsByApiKeyId} - The main response type definition
+ * @see {@link DELETE_AuthClientCredentialsByApiKeyId_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type DELETE_AuthClientCredentialsByApiKeyId_Response_401 = Problem
@@ -249,7 +237,7 @@ export type DELETE_AuthClientCredentialsByApiKeyId_Response_401 = Problem
  *
  * @path /v1/auth/client_credentials/{api_key_id}
  *
- * @see {@link DELETE_AuthClientCredentialsByApiKeyId} - The main response type definition
+ * @see {@link DELETE_AuthClientCredentialsByApiKeyId_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type DELETE_AuthClientCredentialsByApiKeyId_Response_404 = Problem
@@ -266,7 +254,7 @@ export type DELETE_AuthClientCredentialsByApiKeyId_Response_404 = Problem
  *
  * @path /v1/auth/client_credentials/{api_key_id}
  *
- * @see {@link DELETE_AuthClientCredentialsByApiKeyId} - The main response type definition
+ * @see {@link DELETE_AuthClientCredentialsByApiKeyId_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type DELETE_AuthClientCredentialsByApiKeyId_Response_422 = HTTPValidationError
@@ -289,9 +277,7 @@ export type DELETE_AuthClientCredentialsByApiKeyId_Response_422 = HTTPValidation
  *
 
  */
-export type POST_AuthLogout = {
-  401: POST_AuthLogout_Response_401
-}
+export type POST_AuthLogout_Response = POST_AuthLogout_Response_401;
 
 /**
  * 401 response for POST AuthLogout endpoint
@@ -305,7 +291,7 @@ export type POST_AuthLogout = {
  *
  * @path /v1/auth/logout
  *
- * @see {@link POST_AuthLogout} - The main response type definition
+ * @see {@link POST_AuthLogout_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type POST_AuthLogout_Response_401 = Problem
@@ -329,10 +315,7 @@ export type POST_AuthLogout_Response_401 = Problem
  *
 
  */
-export type POST_AuthSignup = {
-  409: POST_AuthSignup_Response_409
-  422: POST_AuthSignup_Response_422
-}
+export type POST_AuthSignup_Response = POST_AuthSignup_Response_409 | POST_AuthSignup_Response_422;
 
 /**
  * 409 response for POST AuthSignup endpoint
@@ -346,7 +329,7 @@ export type POST_AuthSignup = {
  *
  * @path /v1/auth/signup
  *
- * @see {@link POST_AuthSignup} - The main response type definition
+ * @see {@link POST_AuthSignup_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type POST_AuthSignup_Response_409 = Problem
@@ -363,7 +346,7 @@ export type POST_AuthSignup_Response_409 = Problem
  *
  * @path /v1/auth/signup
  *
- * @see {@link POST_AuthSignup} - The main response type definition
+ * @see {@link POST_AuthSignup_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type POST_AuthSignup_Response_422 = HTTPValidationError
@@ -387,10 +370,7 @@ export type POST_AuthSignup_Response_422 = HTTPValidationError
  *
 
  */
-export type POST_AuthToken = {
-  401: POST_AuthToken_Response_401
-  422: POST_AuthToken_Response_422
-}
+export type POST_AuthToken_Response = POST_AuthToken_Response_401 | POST_AuthToken_Response_422;
 
 /**
  * 401 response for POST AuthToken endpoint
@@ -404,7 +384,7 @@ export type POST_AuthToken = {
  *
  * @path /v1/auth/token
  *
- * @see {@link POST_AuthToken} - The main response type definition
+ * @see {@link POST_AuthToken_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type POST_AuthToken_Response_401 = Problem
@@ -421,7 +401,7 @@ export type POST_AuthToken_Response_401 = Problem
  *
  * @path /v1/auth/token
  *
- * @see {@link POST_AuthToken} - The main response type definition
+ * @see {@link POST_AuthToken_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type POST_AuthToken_Response_422 = HTTPValidationError
@@ -451,12 +431,7 @@ Specify one or more domains to check for availability.
  *
 
  */
-export type GET_Availability = {
-  200: GET_Availability_Response_200
-  401: GET_Availability_Response_401
-  422: GET_Availability_Response_422
-  502: GET_Availability_Response_502
-}
+export type GET_Availability_Response = GET_Availability_Response_200 | GET_Availability_Response_401 | GET_Availability_Response_422 | GET_Availability_Response_502;
 
 /**
  * 200 response for GET Availability endpoint
@@ -473,7 +448,7 @@ export type GET_Availability = {
 Specify one or more domains to check for availability.
 
  *
- * @see {@link GET_Availability} - The main response type definition
+ * @see {@link GET_Availability_Response} - The main response type definition
  * @see {@link DomainAvailabilityList} - The actual schema type definition
  */
 export type GET_Availability_Response_200 = DomainAvailabilityList
@@ -493,7 +468,7 @@ export type GET_Availability_Response_200 = DomainAvailabilityList
 Specify one or more domains to check for availability.
 
  *
- * @see {@link GET_Availability} - The main response type definition
+ * @see {@link GET_Availability_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type GET_Availability_Response_401 = Problem
@@ -513,7 +488,7 @@ export type GET_Availability_Response_401 = Problem
 Specify one or more domains to check for availability.
 
  *
- * @see {@link GET_Availability} - The main response type definition
+ * @see {@link GET_Availability_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type GET_Availability_Response_422 = HTTPValidationError
@@ -533,7 +508,7 @@ export type GET_Availability_Response_422 = HTTPValidationError
 Specify one or more domains to check for availability.
 
  *
- * @see {@link GET_Availability} - The main response type definition
+ * @see {@link GET_Availability_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type GET_Availability_Response_502 = Problem
@@ -562,11 +537,7 @@ Specify one or more domains to check for availability.
  *
 
  */
-export type GET_AvailabilityStream = {
-  401: GET_AvailabilityStream_Response_401
-  422: GET_AvailabilityStream_Response_422
-  502: GET_AvailabilityStream_Response_502
-}
+export type GET_AvailabilityStream_Response = GET_AvailabilityStream_Response_401 | GET_AvailabilityStream_Response_422 | GET_AvailabilityStream_Response_502;
 
 /**
  * 401 response for GET AvailabilityStream endpoint
@@ -583,7 +554,7 @@ export type GET_AvailabilityStream = {
 Specify one or more domains to check for availability.
 
  *
- * @see {@link GET_AvailabilityStream} - The main response type definition
+ * @see {@link GET_AvailabilityStream_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type GET_AvailabilityStream_Response_401 = Problem
@@ -603,7 +574,7 @@ export type GET_AvailabilityStream_Response_401 = Problem
 Specify one or more domains to check for availability.
 
  *
- * @see {@link GET_AvailabilityStream} - The main response type definition
+ * @see {@link GET_AvailabilityStream_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type GET_AvailabilityStream_Response_422 = HTTPValidationError
@@ -623,7 +594,7 @@ export type GET_AvailabilityStream_Response_422 = HTTPValidationError
 Specify one or more domains to check for availability.
 
  *
- * @see {@link GET_AvailabilityStream} - The main response type definition
+ * @see {@link GET_AvailabilityStream_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type GET_AvailabilityStream_Response_502 = Problem
@@ -648,10 +619,7 @@ export type GET_AvailabilityStream_Response_502 = Problem
  *
 
  */
-export type GET_Contacts = {
-  200: GET_Contacts_Response_200
-  422: GET_Contacts_Response_422
-}
+export type GET_Contacts_Response = GET_Contacts_Response_200 | GET_Contacts_Response_422;
 
 /**
  * 200 response for GET Contacts endpoint
@@ -665,7 +633,7 @@ export type GET_Contacts = {
  *
  * @path /v1/contacts
  *
- * @see {@link GET_Contacts} - The main response type definition
+ * @see {@link GET_Contacts_Response} - The main response type definition
  * @see {@link Pagination_ContactSchema} - The actual schema type definition
  */
 export type GET_Contacts_Response_200 = Pagination_ContactSchema
@@ -682,7 +650,7 @@ export type GET_Contacts_Response_200 = Pagination_ContactSchema
  *
  * @path /v1/contacts
  *
- * @see {@link GET_Contacts} - The main response type definition
+ * @see {@link GET_Contacts_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type GET_Contacts_Response_422 = HTTPValidationError
@@ -707,10 +675,7 @@ export type GET_Contacts_Response_422 = HTTPValidationError
  *
 
  */
-export type POST_Contacts = {
-  201: POST_Contacts_Response_201
-  422: POST_Contacts_Response_422
-}
+export type POST_Contacts_Response = POST_Contacts_Response_201 | POST_Contacts_Response_422;
 
 /**
  * 201 response for POST Contacts endpoint
@@ -724,7 +689,7 @@ export type POST_Contacts = {
  *
  * @path /v1/contacts
  *
- * @see {@link POST_Contacts} - The main response type definition
+ * @see {@link POST_Contacts_Response} - The main response type definition
  * @see {@link ContactSchema} - The actual schema type definition
  */
 export type POST_Contacts_Response_201 = ContactSchema
@@ -741,7 +706,7 @@ export type POST_Contacts_Response_201 = ContactSchema
  *
  * @path /v1/contacts
  *
- * @see {@link POST_Contacts} - The main response type definition
+ * @see {@link POST_Contacts_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type POST_Contacts_Response_422 = HTTPValidationError
@@ -767,11 +732,7 @@ export type POST_Contacts_Response_422 = HTTPValidationError
  *
 
  */
-export type DELETE_ContactsByContactId = {
-  404: DELETE_ContactsByContactId_Response_404
-  409: DELETE_ContactsByContactId_Response_409
-  422: DELETE_ContactsByContactId_Response_422
-}
+export type DELETE_ContactsByContactId_Response = DELETE_ContactsByContactId_Response_404 | DELETE_ContactsByContactId_Response_409 | DELETE_ContactsByContactId_Response_422;
 
 /**
  * 404 response for DELETE ContactsByContactId endpoint
@@ -785,7 +746,7 @@ export type DELETE_ContactsByContactId = {
  *
  * @path /v1/contacts/{contact_id}
  *
- * @see {@link DELETE_ContactsByContactId} - The main response type definition
+ * @see {@link DELETE_ContactsByContactId_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type DELETE_ContactsByContactId_Response_404 = Problem
@@ -802,7 +763,7 @@ export type DELETE_ContactsByContactId_Response_404 = Problem
  *
  * @path /v1/contacts/{contact_id}
  *
- * @see {@link DELETE_ContactsByContactId} - The main response type definition
+ * @see {@link DELETE_ContactsByContactId_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type DELETE_ContactsByContactId_Response_409 = Problem
@@ -819,7 +780,7 @@ export type DELETE_ContactsByContactId_Response_409 = Problem
  *
  * @path /v1/contacts/{contact_id}
  *
- * @see {@link DELETE_ContactsByContactId} - The main response type definition
+ * @see {@link DELETE_ContactsByContactId_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type DELETE_ContactsByContactId_Response_422 = HTTPValidationError
@@ -845,11 +806,7 @@ export type DELETE_ContactsByContactId_Response_422 = HTTPValidationError
  *
 
  */
-export type GET_ContactsByContactId = {
-  200: GET_ContactsByContactId_Response_200
-  404: GET_ContactsByContactId_Response_404
-  422: GET_ContactsByContactId_Response_422
-}
+export type GET_ContactsByContactId_Response = GET_ContactsByContactId_Response_200 | GET_ContactsByContactId_Response_404 | GET_ContactsByContactId_Response_422;
 
 /**
  * 200 response for GET ContactsByContactId endpoint
@@ -863,7 +820,7 @@ export type GET_ContactsByContactId = {
  *
  * @path /v1/contacts/{contact_id}
  *
- * @see {@link GET_ContactsByContactId} - The main response type definition
+ * @see {@link GET_ContactsByContactId_Response} - The main response type definition
  * @see {@link ContactSchema} - The actual schema type definition
  */
 export type GET_ContactsByContactId_Response_200 = ContactSchema
@@ -880,7 +837,7 @@ export type GET_ContactsByContactId_Response_200 = ContactSchema
  *
  * @path /v1/contacts/{contact_id}
  *
- * @see {@link GET_ContactsByContactId} - The main response type definition
+ * @see {@link GET_ContactsByContactId_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type GET_ContactsByContactId_Response_404 = Problem
@@ -897,7 +854,7 @@ export type GET_ContactsByContactId_Response_404 = Problem
  *
  * @path /v1/contacts/{contact_id}
  *
- * @see {@link GET_ContactsByContactId} - The main response type definition
+ * @see {@link GET_ContactsByContactId_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type GET_ContactsByContactId_Response_422 = HTTPValidationError
@@ -923,11 +880,7 @@ export type GET_ContactsByContactId_Response_422 = HTTPValidationError
  *
 
  */
-export type DELETE_ContactsByContactIdVerification = {
-  401: DELETE_ContactsByContactIdVerification_Response_401
-  404: DELETE_ContactsByContactIdVerification_Response_404
-  422: DELETE_ContactsByContactIdVerification_Response_422
-}
+export type DELETE_ContactsByContactIdVerification_Response = DELETE_ContactsByContactIdVerification_Response_401 | DELETE_ContactsByContactIdVerification_Response_404 | DELETE_ContactsByContactIdVerification_Response_422;
 
 /**
  * 401 response for DELETE ContactsByContactIdVerification endpoint
@@ -941,7 +894,7 @@ export type DELETE_ContactsByContactIdVerification = {
  *
  * @path /v1/contacts/{contact_id}/verification
  *
- * @see {@link DELETE_ContactsByContactIdVerification} - The main response type definition
+ * @see {@link DELETE_ContactsByContactIdVerification_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type DELETE_ContactsByContactIdVerification_Response_401 = Problem
@@ -958,7 +911,7 @@ export type DELETE_ContactsByContactIdVerification_Response_401 = Problem
  *
  * @path /v1/contacts/{contact_id}/verification
  *
- * @see {@link DELETE_ContactsByContactIdVerification} - The main response type definition
+ * @see {@link DELETE_ContactsByContactIdVerification_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type DELETE_ContactsByContactIdVerification_Response_404 = Problem
@@ -975,7 +928,7 @@ export type DELETE_ContactsByContactIdVerification_Response_404 = Problem
  *
  * @path /v1/contacts/{contact_id}/verification
  *
- * @see {@link DELETE_ContactsByContactIdVerification} - The main response type definition
+ * @see {@link DELETE_ContactsByContactIdVerification_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type DELETE_ContactsByContactIdVerification_Response_422 = HTTPValidationError
@@ -1002,12 +955,7 @@ export type DELETE_ContactsByContactIdVerification_Response_422 = HTTPValidation
  *
 
  */
-export type GET_ContactsByContactIdVerification = {
-  200: GET_ContactsByContactIdVerification_Response_200
-  401: GET_ContactsByContactIdVerification_Response_401
-  404: GET_ContactsByContactIdVerification_Response_404
-  422: GET_ContactsByContactIdVerification_Response_422
-}
+export type GET_ContactsByContactIdVerification_Response = GET_ContactsByContactIdVerification_Response_200 | GET_ContactsByContactIdVerification_Response_401 | GET_ContactsByContactIdVerification_Response_404 | GET_ContactsByContactIdVerification_Response_422;
 
 /**
  * 200 response for GET ContactsByContactIdVerification endpoint
@@ -1021,7 +969,7 @@ export type GET_ContactsByContactIdVerification = {
  *
  * @path /v1/contacts/{contact_id}/verification
  *
- * @see {@link GET_ContactsByContactIdVerification} - The main response type definition
+ * @see {@link GET_ContactsByContactIdVerification_Response} - The main response type definition
  * @see {@link ContactVerification} - The actual schema type definition
  */
 export type GET_ContactsByContactIdVerification_Response_200 = ContactVerification
@@ -1038,7 +986,7 @@ export type GET_ContactsByContactIdVerification_Response_200 = ContactVerificati
  *
  * @path /v1/contacts/{contact_id}/verification
  *
- * @see {@link GET_ContactsByContactIdVerification} - The main response type definition
+ * @see {@link GET_ContactsByContactIdVerification_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type GET_ContactsByContactIdVerification_Response_401 = Problem
@@ -1055,7 +1003,7 @@ export type GET_ContactsByContactIdVerification_Response_401 = Problem
  *
  * @path /v1/contacts/{contact_id}/verification
  *
- * @see {@link GET_ContactsByContactIdVerification} - The main response type definition
+ * @see {@link GET_ContactsByContactIdVerification_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type GET_ContactsByContactIdVerification_Response_404 = Problem
@@ -1072,7 +1020,7 @@ export type GET_ContactsByContactIdVerification_Response_404 = Problem
  *
  * @path /v1/contacts/{contact_id}/verification
  *
- * @see {@link GET_ContactsByContactIdVerification} - The main response type definition
+ * @see {@link GET_ContactsByContactIdVerification_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type GET_ContactsByContactIdVerification_Response_422 = HTTPValidationError
@@ -1099,12 +1047,7 @@ export type GET_ContactsByContactIdVerification_Response_422 = HTTPValidationErr
  *
 
  */
-export type POST_ContactsByContactIdVerification = {
-  401: POST_ContactsByContactIdVerification_Response_401
-  404: POST_ContactsByContactIdVerification_Response_404
-  405: POST_ContactsByContactIdVerification_Response_405
-  422: POST_ContactsByContactIdVerification_Response_422
-}
+export type POST_ContactsByContactIdVerification_Response = POST_ContactsByContactIdVerification_Response_401 | POST_ContactsByContactIdVerification_Response_404 | POST_ContactsByContactIdVerification_Response_405 | POST_ContactsByContactIdVerification_Response_422;
 
 /**
  * 401 response for POST ContactsByContactIdVerification endpoint
@@ -1118,7 +1061,7 @@ export type POST_ContactsByContactIdVerification = {
  *
  * @path /v1/contacts/{contact_id}/verification
  *
- * @see {@link POST_ContactsByContactIdVerification} - The main response type definition
+ * @see {@link POST_ContactsByContactIdVerification_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type POST_ContactsByContactIdVerification_Response_401 = Problem
@@ -1135,7 +1078,7 @@ export type POST_ContactsByContactIdVerification_Response_401 = Problem
  *
  * @path /v1/contacts/{contact_id}/verification
  *
- * @see {@link POST_ContactsByContactIdVerification} - The main response type definition
+ * @see {@link POST_ContactsByContactIdVerification_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type POST_ContactsByContactIdVerification_Response_404 = Problem
@@ -1152,7 +1095,7 @@ export type POST_ContactsByContactIdVerification_Response_404 = Problem
  *
  * @path /v1/contacts/{contact_id}/verification
  *
- * @see {@link POST_ContactsByContactIdVerification} - The main response type definition
+ * @see {@link POST_ContactsByContactIdVerification_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type POST_ContactsByContactIdVerification_Response_405 = Problem
@@ -1169,7 +1112,7 @@ export type POST_ContactsByContactIdVerification_Response_405 = Problem
  *
  * @path /v1/contacts/{contact_id}/verification
  *
- * @see {@link POST_ContactsByContactIdVerification} - The main response type definition
+ * @see {@link POST_ContactsByContactIdVerification_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type POST_ContactsByContactIdVerification_Response_422 = HTTPValidationError
@@ -1197,13 +1140,7 @@ export type POST_ContactsByContactIdVerification_Response_422 = HTTPValidationEr
  *
 
  */
-export type PUT_ContactsByContactIdVerification = {
-  400: PUT_ContactsByContactIdVerification_Response_400
-  401: PUT_ContactsByContactIdVerification_Response_401
-  403: PUT_ContactsByContactIdVerification_Response_403
-  404: PUT_ContactsByContactIdVerification_Response_404
-  422: PUT_ContactsByContactIdVerification_Response_422
-}
+export type PUT_ContactsByContactIdVerification_Response = PUT_ContactsByContactIdVerification_Response_400 | PUT_ContactsByContactIdVerification_Response_401 | PUT_ContactsByContactIdVerification_Response_403 | PUT_ContactsByContactIdVerification_Response_404 | PUT_ContactsByContactIdVerification_Response_422;
 
 /**
  * 400 response for PUT ContactsByContactIdVerification endpoint
@@ -1217,7 +1154,7 @@ export type PUT_ContactsByContactIdVerification = {
  *
  * @path /v1/contacts/{contact_id}/verification
  *
- * @see {@link PUT_ContactsByContactIdVerification} - The main response type definition
+ * @see {@link PUT_ContactsByContactIdVerification_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type PUT_ContactsByContactIdVerification_Response_400 = Problem
@@ -1234,7 +1171,7 @@ export type PUT_ContactsByContactIdVerification_Response_400 = Problem
  *
  * @path /v1/contacts/{contact_id}/verification
  *
- * @see {@link PUT_ContactsByContactIdVerification} - The main response type definition
+ * @see {@link PUT_ContactsByContactIdVerification_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type PUT_ContactsByContactIdVerification_Response_401 = Problem
@@ -1251,7 +1188,7 @@ export type PUT_ContactsByContactIdVerification_Response_401 = Problem
  *
  * @path /v1/contacts/{contact_id}/verification
  *
- * @see {@link PUT_ContactsByContactIdVerification} - The main response type definition
+ * @see {@link PUT_ContactsByContactIdVerification_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type PUT_ContactsByContactIdVerification_Response_403 = Problem
@@ -1268,7 +1205,7 @@ export type PUT_ContactsByContactIdVerification_Response_403 = Problem
  *
  * @path /v1/contacts/{contact_id}/verification
  *
- * @see {@link PUT_ContactsByContactIdVerification} - The main response type definition
+ * @see {@link PUT_ContactsByContactIdVerification_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type PUT_ContactsByContactIdVerification_Response_404 = Problem
@@ -1285,7 +1222,7 @@ export type PUT_ContactsByContactIdVerification_Response_404 = Problem
  *
  * @path /v1/contacts/{contact_id}/verification
  *
- * @see {@link PUT_ContactsByContactIdVerification} - The main response type definition
+ * @see {@link PUT_ContactsByContactIdVerification_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type PUT_ContactsByContactIdVerification_Response_422 = HTTPValidationError
@@ -1312,12 +1249,7 @@ export type PUT_ContactsByContactIdVerification_Response_422 = HTTPValidationErr
  *
 
  */
-export type GET_ContactsVerification = {
-  200: GET_ContactsVerification_Response_200
-  401: GET_ContactsVerification_Response_401
-  404: GET_ContactsVerification_Response_404
-  422: GET_ContactsVerification_Response_422
-}
+export type GET_ContactsVerification_Response = GET_ContactsVerification_Response_200 | GET_ContactsVerification_Response_401 | GET_ContactsVerification_Response_404 | GET_ContactsVerification_Response_422;
 
 /**
  * 200 response for GET ContactsVerification endpoint
@@ -1331,7 +1263,7 @@ export type GET_ContactsVerification = {
  *
  * @path /v1/contacts/verification
  *
- * @see {@link GET_ContactsVerification} - The main response type definition
+ * @see {@link GET_ContactsVerification_Response} - The main response type definition
  * @see {@link Contact} - The actual schema type definition
  */
 export type GET_ContactsVerification_Response_200 = Contact
@@ -1348,7 +1280,7 @@ export type GET_ContactsVerification_Response_200 = Contact
  *
  * @path /v1/contacts/verification
  *
- * @see {@link GET_ContactsVerification} - The main response type definition
+ * @see {@link GET_ContactsVerification_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type GET_ContactsVerification_Response_401 = Problem
@@ -1365,7 +1297,7 @@ export type GET_ContactsVerification_Response_401 = Problem
  *
  * @path /v1/contacts/verification
  *
- * @see {@link GET_ContactsVerification} - The main response type definition
+ * @see {@link GET_ContactsVerification_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type GET_ContactsVerification_Response_404 = Problem
@@ -1382,7 +1314,7 @@ export type GET_ContactsVerification_Response_404 = Problem
  *
  * @path /v1/contacts/verification
  *
- * @see {@link GET_ContactsVerification} - The main response type definition
+ * @see {@link GET_ContactsVerification_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type GET_ContactsVerification_Response_422 = HTTPValidationError
@@ -1409,12 +1341,7 @@ export type GET_ContactsVerification_Response_422 = HTTPValidationError
  *
 
  */
-export type PUT_ContactsVerification = {
-  400: PUT_ContactsVerification_Response_400
-  401: PUT_ContactsVerification_Response_401
-  404: PUT_ContactsVerification_Response_404
-  422: PUT_ContactsVerification_Response_422
-}
+export type PUT_ContactsVerification_Response = PUT_ContactsVerification_Response_400 | PUT_ContactsVerification_Response_401 | PUT_ContactsVerification_Response_404 | PUT_ContactsVerification_Response_422;
 
 /**
  * 400 response for PUT ContactsVerification endpoint
@@ -1428,7 +1355,7 @@ export type PUT_ContactsVerification = {
  *
  * @path /v1/contacts/verification
  *
- * @see {@link PUT_ContactsVerification} - The main response type definition
+ * @see {@link PUT_ContactsVerification_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type PUT_ContactsVerification_Response_400 = Problem
@@ -1445,7 +1372,7 @@ export type PUT_ContactsVerification_Response_400 = Problem
  *
  * @path /v1/contacts/verification
  *
- * @see {@link PUT_ContactsVerification} - The main response type definition
+ * @see {@link PUT_ContactsVerification_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type PUT_ContactsVerification_Response_401 = Problem
@@ -1462,7 +1389,7 @@ export type PUT_ContactsVerification_Response_401 = Problem
  *
  * @path /v1/contacts/verification
  *
- * @see {@link PUT_ContactsVerification} - The main response type definition
+ * @see {@link PUT_ContactsVerification_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type PUT_ContactsVerification_Response_404 = Problem
@@ -1479,7 +1406,7 @@ export type PUT_ContactsVerification_Response_404 = Problem
  *
  * @path /v1/contacts/verification
  *
- * @see {@link PUT_ContactsVerification} - The main response type definition
+ * @see {@link PUT_ContactsVerification_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type PUT_ContactsVerification_Response_422 = HTTPValidationError
@@ -1502,9 +1429,7 @@ export type PUT_ContactsVerification_Response_422 = HTTPValidationError
  *
 
  */
-export type GET_ContactsVerify = {
-  422: GET_ContactsVerify_Response_422
-}
+export type GET_ContactsVerify_Response = GET_ContactsVerify_Response_422;
 
 /**
  * 422 response for GET ContactsVerify endpoint
@@ -1518,7 +1443,7 @@ export type GET_ContactsVerify = {
  *
  * @path /v1/contacts/verify
  *
- * @see {@link GET_ContactsVerify} - The main response type definition
+ * @see {@link GET_ContactsVerify_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type GET_ContactsVerify_Response_422 = HTTPValidationError
@@ -1542,10 +1467,7 @@ export type GET_ContactsVerify_Response_422 = HTTPValidationError
  *
 
  */
-export type GET_Dns = {
-  200: GET_Dns_Response_200
-  422: GET_Dns_Response_422
-}
+export type GET_Dns_Response = GET_Dns_Response_200 | GET_Dns_Response_422;
 
 /**
  * 200 response for GET Dns endpoint
@@ -1559,7 +1481,7 @@ export type GET_Dns = {
  *
  * @path /v1/dns
  *
- * @see {@link GET_Dns} - The main response type definition
+ * @see {@link GET_Dns_Response} - The main response type definition
  * @see {@link Pagination_DnsZone} - The actual schema type definition
  */
 export type GET_Dns_Response_200 = Pagination_DnsZone
@@ -1576,7 +1498,7 @@ export type GET_Dns_Response_200 = Pagination_DnsZone
  *
  * @path /v1/dns
  *
- * @see {@link GET_Dns} - The main response type definition
+ * @see {@link GET_Dns_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type GET_Dns_Response_422 = HTTPValidationError
@@ -1599,9 +1521,7 @@ export type GET_Dns_Response_422 = HTTPValidationError
  *
 
  */
-export type POST_Dns = {
-  422: POST_Dns_Response_422
-}
+export type POST_Dns_Response = POST_Dns_Response_422;
 
 /**
  * 422 response for POST Dns endpoint
@@ -1615,7 +1535,7 @@ export type POST_Dns = {
  *
  * @path /v1/dns
  *
- * @see {@link POST_Dns} - The main response type definition
+ * @see {@link POST_Dns_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type POST_Dns_Response_422 = HTTPValidationError
@@ -1639,9 +1559,7 @@ export type POST_Dns_Response_422 = HTTPValidationError
  *
 
  */
-export type DELETE_DnsByZoneName = {
-  422: DELETE_DnsByZoneName_Response_422
-}
+export type DELETE_DnsByZoneName_Response = DELETE_DnsByZoneName_Response_422;
 
 /**
  * 422 response for DELETE DnsByZoneName endpoint
@@ -1656,7 +1574,7 @@ export type DELETE_DnsByZoneName = {
  * @path /v1/dns/{zone_name}
  * @param zone_name (path) - DNS zone name (trailing dot optional)
  *
- * @see {@link DELETE_DnsByZoneName} - The main response type definition
+ * @see {@link DELETE_DnsByZoneName_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type DELETE_DnsByZoneName_Response_422 = HTTPValidationError
@@ -1681,10 +1599,7 @@ export type DELETE_DnsByZoneName_Response_422 = HTTPValidationError
  *
 
  */
-export type GET_DnsByZoneName = {
-  200: GET_DnsByZoneName_Response_200
-  422: GET_DnsByZoneName_Response_422
-}
+export type GET_DnsByZoneName_Response = GET_DnsByZoneName_Response_200 | GET_DnsByZoneName_Response_422;
 
 /**
  * 200 response for GET DnsByZoneName endpoint
@@ -1699,7 +1614,7 @@ export type GET_DnsByZoneName = {
  * @path /v1/dns/{zone_name}
  * @param zone_name (path) - DNS zone name (trailing dot optional)
  *
- * @see {@link GET_DnsByZoneName} - The main response type definition
+ * @see {@link GET_DnsByZoneName_Response} - The main response type definition
  * @see {@link DnsZone} - The actual schema type definition
  */
 export type GET_DnsByZoneName_Response_200 = DnsZone
@@ -1717,7 +1632,7 @@ export type GET_DnsByZoneName_Response_200 = DnsZone
  * @path /v1/dns/{zone_name}
  * @param zone_name (path) - DNS zone name (trailing dot optional)
  *
- * @see {@link GET_DnsByZoneName} - The main response type definition
+ * @see {@link GET_DnsByZoneName_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type GET_DnsByZoneName_Response_422 = HTTPValidationError
@@ -1742,10 +1657,7 @@ export type GET_DnsByZoneName_Response_422 = HTTPValidationError
  *
 
  */
-export type POST_DnsByZoneNameDnssecDisable = {
-  200: POST_DnsByZoneNameDnssecDisable_Response_200
-  422: POST_DnsByZoneNameDnssecDisable_Response_422
-}
+export type POST_DnsByZoneNameDnssecDisable_Response = POST_DnsByZoneNameDnssecDisable_Response_200 | POST_DnsByZoneNameDnssecDisable_Response_422;
 
 /**
  * 200 response for POST DnsByZoneNameDnssecDisable endpoint
@@ -1760,7 +1672,7 @@ export type POST_DnsByZoneNameDnssecDisable = {
  * @path /v1/dns/{zone_name}/dnssec/disable
  * @param zone_name (path) - DNS zone name (trailing dot optional)
  *
- * @see {@link POST_DnsByZoneNameDnssecDisable} - The main response type definition
+ * @see {@link POST_DnsByZoneNameDnssecDisable_Response} - The main response type definition
  * @see {@link DnsChanges} - The actual schema type definition
  */
 export type POST_DnsByZoneNameDnssecDisable_Response_200 = DnsChanges
@@ -1778,7 +1690,7 @@ export type POST_DnsByZoneNameDnssecDisable_Response_200 = DnsChanges
  * @path /v1/dns/{zone_name}/dnssec/disable
  * @param zone_name (path) - DNS zone name (trailing dot optional)
  *
- * @see {@link POST_DnsByZoneNameDnssecDisable} - The main response type definition
+ * @see {@link POST_DnsByZoneNameDnssecDisable_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type POST_DnsByZoneNameDnssecDisable_Response_422 = HTTPValidationError
@@ -1803,10 +1715,7 @@ export type POST_DnsByZoneNameDnssecDisable_Response_422 = HTTPValidationError
  *
 
  */
-export type POST_DnsByZoneNameDnssecEnable = {
-  200: POST_DnsByZoneNameDnssecEnable_Response_200
-  422: POST_DnsByZoneNameDnssecEnable_Response_422
-}
+export type POST_DnsByZoneNameDnssecEnable_Response = POST_DnsByZoneNameDnssecEnable_Response_200 | POST_DnsByZoneNameDnssecEnable_Response_422;
 
 /**
  * 200 response for POST DnsByZoneNameDnssecEnable endpoint
@@ -1821,7 +1730,7 @@ export type POST_DnsByZoneNameDnssecEnable = {
  * @path /v1/dns/{zone_name}/dnssec/enable
  * @param zone_name (path) - DNS zone name (trailing dot optional)
  *
- * @see {@link POST_DnsByZoneNameDnssecEnable} - The main response type definition
+ * @see {@link POST_DnsByZoneNameDnssecEnable_Response} - The main response type definition
  * @see {@link DnsChanges} - The actual schema type definition
  */
 export type POST_DnsByZoneNameDnssecEnable_Response_200 = DnsChanges
@@ -1839,7 +1748,7 @@ export type POST_DnsByZoneNameDnssecEnable_Response_200 = DnsChanges
  * @path /v1/dns/{zone_name}/dnssec/enable
  * @param zone_name (path) - DNS zone name (trailing dot optional)
  *
- * @see {@link POST_DnsByZoneNameDnssecEnable} - The main response type definition
+ * @see {@link POST_DnsByZoneNameDnssecEnable_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type POST_DnsByZoneNameDnssecEnable_Response_422 = HTTPValidationError
@@ -1863,9 +1772,7 @@ export type POST_DnsByZoneNameDnssecEnable_Response_422 = HTTPValidationError
  *
 
  */
-export type PATCH_DnsByZoneNameRecords = {
-  422: PATCH_DnsByZoneNameRecords_Response_422
-}
+export type PATCH_DnsByZoneNameRecords_Response = PATCH_DnsByZoneNameRecords_Response_422;
 
 /**
  * 422 response for PATCH DnsByZoneNameRecords endpoint
@@ -1880,7 +1787,7 @@ export type PATCH_DnsByZoneNameRecords = {
  * @path /v1/dns/{zone_name}/records
  * @param zone_name (path) - DNS zone name (trailing dot optional)
  *
- * @see {@link PATCH_DnsByZoneNameRecords} - The main response type definition
+ * @see {@link PATCH_DnsByZoneNameRecords_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type PATCH_DnsByZoneNameRecords_Response_422 = HTTPValidationError
@@ -1904,9 +1811,7 @@ export type PATCH_DnsByZoneNameRecords_Response_422 = HTTPValidationError
  *
 
  */
-export type PATCH_DnsByZoneNameRrsets = {
-  422: PATCH_DnsByZoneNameRrsets_Response_422
-}
+export type PATCH_DnsByZoneNameRrsets_Response = PATCH_DnsByZoneNameRrsets_Response_422;
 
 /**
  * 422 response for PATCH DnsByZoneNameRrsets endpoint
@@ -1921,7 +1826,7 @@ export type PATCH_DnsByZoneNameRrsets = {
  * @path /v1/dns/{zone_name}/rrsets
  * @param zone_name (path) - DNS zone name (trailing dot optional)
  *
- * @see {@link PATCH_DnsByZoneNameRrsets} - The main response type definition
+ * @see {@link PATCH_DnsByZoneNameRrsets_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type PATCH_DnsByZoneNameRrsets_Response_422 = HTTPValidationError
@@ -1945,9 +1850,7 @@ export type PATCH_DnsByZoneNameRrsets_Response_422 = HTTPValidationError
  *
 
  */
-export type PUT_DnsByZoneNameRrsets = {
-  422: PUT_DnsByZoneNameRrsets_Response_422
-}
+export type PUT_DnsByZoneNameRrsets_Response = PUT_DnsByZoneNameRrsets_Response_422;
 
 /**
  * 422 response for PUT DnsByZoneNameRrsets endpoint
@@ -1962,7 +1865,7 @@ export type PUT_DnsByZoneNameRrsets = {
  * @path /v1/dns/{zone_name}/rrsets
  * @param zone_name (path) - DNS zone name (trailing dot optional)
  *
- * @see {@link PUT_DnsByZoneNameRrsets} - The main response type definition
+ * @see {@link PUT_DnsByZoneNameRrsets_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type PUT_DnsByZoneNameRrsets_Response_422 = HTTPValidationError
@@ -1994,12 +1897,7 @@ Specify one or more TLDs to include in the search.
  *
 
  */
-export type GET_DomainSearchSuggest = {
-  200: GET_DomainSearchSuggest_Response_200
-  401: GET_DomainSearchSuggest_Response_401
-  422: GET_DomainSearchSuggest_Response_422
-  502: GET_DomainSearchSuggest_Response_502
-}
+export type GET_DomainSearchSuggest_Response = GET_DomainSearchSuggest_Response_200 | GET_DomainSearchSuggest_Response_401 | GET_DomainSearchSuggest_Response_422 | GET_DomainSearchSuggest_Response_502;
 
 /**
  * 200 response for GET DomainSearchSuggest endpoint
@@ -2019,7 +1917,7 @@ Specify one or more TLDs to include in the search.
  * @param limit (query) - The maximum number of domain suggestions to return
  * @param premium (query) - Whether to include premium domains in the suggestions
  *
- * @see {@link GET_DomainSearchSuggest} - The main response type definition
+ * @see {@link GET_DomainSearchSuggest_Response} - The main response type definition
  * @see {@link DomainSearch} - The actual schema type definition
  */
 export type GET_DomainSearchSuggest_Response_200 = DomainSearch
@@ -2042,7 +1940,7 @@ Specify one or more TLDs to include in the search.
  * @param limit (query) - The maximum number of domain suggestions to return
  * @param premium (query) - Whether to include premium domains in the suggestions
  *
- * @see {@link GET_DomainSearchSuggest} - The main response type definition
+ * @see {@link GET_DomainSearchSuggest_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type GET_DomainSearchSuggest_Response_401 = Problem
@@ -2065,7 +1963,7 @@ Specify one or more TLDs to include in the search.
  * @param limit (query) - The maximum number of domain suggestions to return
  * @param premium (query) - Whether to include premium domains in the suggestions
  *
- * @see {@link GET_DomainSearchSuggest} - The main response type definition
+ * @see {@link GET_DomainSearchSuggest_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type GET_DomainSearchSuggest_Response_422 = HTTPValidationError
@@ -2088,7 +1986,7 @@ Specify one or more TLDs to include in the search.
  * @param limit (query) - The maximum number of domain suggestions to return
  * @param premium (query) - Whether to include premium domains in the suggestions
  *
- * @see {@link GET_DomainSearchSuggest} - The main response type definition
+ * @see {@link GET_DomainSearchSuggest_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type GET_DomainSearchSuggest_Response_502 = Problem
@@ -2113,10 +2011,7 @@ export type GET_DomainSearchSuggest_Response_502 = Problem
  *
 
  */
-export type GET_Domains = {
-  200: GET_Domains_Response_200
-  422: GET_Domains_Response_422
-}
+export type GET_Domains_Response = GET_Domains_Response_200 | GET_Domains_Response_422;
 
 /**
  * 200 response for GET Domains endpoint
@@ -2130,7 +2025,7 @@ export type GET_Domains = {
  *
  * @path /v1/domains
  *
- * @see {@link GET_Domains} - The main response type definition
+ * @see {@link GET_Domains_Response} - The main response type definition
  * @see {@link Pagination_Domain} - The actual schema type definition
  */
 export type GET_Domains_Response_200 = Pagination_Domain
@@ -2147,7 +2042,7 @@ export type GET_Domains_Response_200 = Pagination_Domain
  *
  * @path /v1/domains
  *
- * @see {@link GET_Domains} - The main response type definition
+ * @see {@link GET_Domains_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type GET_Domains_Response_422 = HTTPValidationError
@@ -2175,13 +2070,7 @@ export type GET_Domains_Response_422 = HTTPValidationError
  *
 
  */
-export type POST_Domains = {
-  201: POST_Domains_Response_201
-  400: POST_Domains_Response_400
-  404: POST_Domains_Response_404
-  409: POST_Domains_Response_409
-  422: POST_Domains_Response_422
-}
+export type POST_Domains_Response = POST_Domains_Response_201 | POST_Domains_Response_400 | POST_Domains_Response_404 | POST_Domains_Response_409 | POST_Domains_Response_422;
 
 /**
  * 201 response for POST Domains endpoint
@@ -2195,7 +2084,7 @@ export type POST_Domains = {
  *
  * @path /v1/domains
  *
- * @see {@link POST_Domains} - The main response type definition
+ * @see {@link POST_Domains_Response} - The main response type definition
  * @see {@link Domain} - The actual schema type definition
  */
 export type POST_Domains_Response_201 = Domain
@@ -2212,7 +2101,7 @@ export type POST_Domains_Response_201 = Domain
  *
  * @path /v1/domains
  *
- * @see {@link POST_Domains} - The main response type definition
+ * @see {@link POST_Domains_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type POST_Domains_Response_400 = Problem
@@ -2229,7 +2118,7 @@ export type POST_Domains_Response_400 = Problem
  *
  * @path /v1/domains
  *
- * @see {@link POST_Domains} - The main response type definition
+ * @see {@link POST_Domains_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type POST_Domains_Response_404 = Problem
@@ -2246,7 +2135,7 @@ export type POST_Domains_Response_404 = Problem
  *
  * @path /v1/domains
  *
- * @see {@link POST_Domains} - The main response type definition
+ * @see {@link POST_Domains_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type POST_Domains_Response_409 = Problem
@@ -2263,7 +2152,7 @@ export type POST_Domains_Response_409 = Problem
  *
  * @path /v1/domains
  *
- * @see {@link POST_Domains} - The main response type definition
+ * @see {@link POST_Domains_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type POST_Domains_Response_422 = HTTPValidationError
@@ -2290,11 +2179,7 @@ and will enter a redemption period during which it may be restored.
  *
 
  */
-export type DELETE_DomainsByDomainReference = {
-  404: DELETE_DomainsByDomainReference_Response_404
-  409: DELETE_DomainsByDomainReference_Response_409
-  422: DELETE_DomainsByDomainReference_Response_422
-}
+export type DELETE_DomainsByDomainReference_Response = DELETE_DomainsByDomainReference_Response_404 | DELETE_DomainsByDomainReference_Response_409 | DELETE_DomainsByDomainReference_Response_422;
 
 /**
  * 404 response for DELETE DomainsByDomainReference endpoint
@@ -2308,7 +2193,7 @@ export type DELETE_DomainsByDomainReference = {
  *
  * @path /v1/domains/{domain_reference}
  *
- * @see {@link DELETE_DomainsByDomainReference} - The main response type definition
+ * @see {@link DELETE_DomainsByDomainReference_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type DELETE_DomainsByDomainReference_Response_404 = Problem
@@ -2325,7 +2210,7 @@ export type DELETE_DomainsByDomainReference_Response_404 = Problem
  *
  * @path /v1/domains/{domain_reference}
  *
- * @see {@link DELETE_DomainsByDomainReference} - The main response type definition
+ * @see {@link DELETE_DomainsByDomainReference_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type DELETE_DomainsByDomainReference_Response_409 = Problem
@@ -2342,7 +2227,7 @@ export type DELETE_DomainsByDomainReference_Response_409 = Problem
  *
  * @path /v1/domains/{domain_reference}
  *
- * @see {@link DELETE_DomainsByDomainReference} - The main response type definition
+ * @see {@link DELETE_DomainsByDomainReference_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type DELETE_DomainsByDomainReference_Response_422 = HTTPValidationError
@@ -2368,11 +2253,7 @@ export type DELETE_DomainsByDomainReference_Response_422 = HTTPValidationError
  *
 
  */
-export type GET_DomainsByDomainReference = {
-  200: GET_DomainsByDomainReference_Response_200
-  404: GET_DomainsByDomainReference_Response_404
-  422: GET_DomainsByDomainReference_Response_422
-}
+export type GET_DomainsByDomainReference_Response = GET_DomainsByDomainReference_Response_200 | GET_DomainsByDomainReference_Response_404 | GET_DomainsByDomainReference_Response_422;
 
 /**
  * 200 response for GET DomainsByDomainReference endpoint
@@ -2386,7 +2267,7 @@ export type GET_DomainsByDomainReference = {
  *
  * @path /v1/domains/{domain_reference}
  *
- * @see {@link GET_DomainsByDomainReference} - The main response type definition
+ * @see {@link GET_DomainsByDomainReference_Response} - The main response type definition
  * @see {@link Domain} - The actual schema type definition
  */
 export type GET_DomainsByDomainReference_Response_200 = Domain
@@ -2403,7 +2284,7 @@ export type GET_DomainsByDomainReference_Response_200 = Domain
  *
  * @path /v1/domains/{domain_reference}
  *
- * @see {@link GET_DomainsByDomainReference} - The main response type definition
+ * @see {@link GET_DomainsByDomainReference_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type GET_DomainsByDomainReference_Response_404 = Problem
@@ -2420,7 +2301,7 @@ export type GET_DomainsByDomainReference_Response_404 = Problem
  *
  * @path /v1/domains/{domain_reference}
  *
- * @see {@link GET_DomainsByDomainReference} - The main response type definition
+ * @see {@link GET_DomainsByDomainReference_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type GET_DomainsByDomainReference_Response_422 = HTTPValidationError
@@ -2448,11 +2329,7 @@ Providing `clientTransferProhibited` as a status will set the `transfer_lock` pr
  *
 
  */
-export type PATCH_DomainsByDomainReference = {
-  200: PATCH_DomainsByDomainReference_Response_200
-  404: PATCH_DomainsByDomainReference_Response_404
-  422: PATCH_DomainsByDomainReference_Response_422
-}
+export type PATCH_DomainsByDomainReference_Response = PATCH_DomainsByDomainReference_Response_200 | PATCH_DomainsByDomainReference_Response_404 | PATCH_DomainsByDomainReference_Response_422;
 
 /**
  * 200 response for PATCH DomainsByDomainReference endpoint
@@ -2466,7 +2343,7 @@ export type PATCH_DomainsByDomainReference = {
  *
  * @path /v1/domains/{domain_reference}
  *
- * @see {@link PATCH_DomainsByDomainReference} - The main response type definition
+ * @see {@link PATCH_DomainsByDomainReference_Response} - The main response type definition
  * @see {@link Domain} - The actual schema type definition
  */
 export type PATCH_DomainsByDomainReference_Response_200 = Domain
@@ -2483,7 +2360,7 @@ export type PATCH_DomainsByDomainReference_Response_200 = Domain
  *
  * @path /v1/domains/{domain_reference}
  *
- * @see {@link PATCH_DomainsByDomainReference} - The main response type definition
+ * @see {@link PATCH_DomainsByDomainReference_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type PATCH_DomainsByDomainReference_Response_404 = Problem
@@ -2500,7 +2377,7 @@ export type PATCH_DomainsByDomainReference_Response_404 = Problem
  *
  * @path /v1/domains/{domain_reference}
  *
- * @see {@link PATCH_DomainsByDomainReference} - The main response type definition
+ * @see {@link PATCH_DomainsByDomainReference_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type PATCH_DomainsByDomainReference_Response_422 = HTTPValidationError
@@ -2525,10 +2402,7 @@ export type PATCH_DomainsByDomainReference_Response_422 = HTTPValidationError
  *
 
  */
-export type DELETE_DomainsByDomainReferenceDnssec = {
-  404: DELETE_DomainsByDomainReferenceDnssec_Response_404
-  422: DELETE_DomainsByDomainReferenceDnssec_Response_422
-}
+export type DELETE_DomainsByDomainReferenceDnssec_Response = DELETE_DomainsByDomainReferenceDnssec_Response_404 | DELETE_DomainsByDomainReferenceDnssec_Response_422;
 
 /**
  * 404 response for DELETE DomainsByDomainReferenceDnssec endpoint
@@ -2542,7 +2416,7 @@ export type DELETE_DomainsByDomainReferenceDnssec = {
  *
  * @path /v1/domains/{domain_reference}/dnssec
  *
- * @see {@link DELETE_DomainsByDomainReferenceDnssec} - The main response type definition
+ * @see {@link DELETE_DomainsByDomainReferenceDnssec_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type DELETE_DomainsByDomainReferenceDnssec_Response_404 = Problem
@@ -2559,7 +2433,7 @@ export type DELETE_DomainsByDomainReferenceDnssec_Response_404 = Problem
  *
  * @path /v1/domains/{domain_reference}/dnssec
  *
- * @see {@link DELETE_DomainsByDomainReferenceDnssec} - The main response type definition
+ * @see {@link DELETE_DomainsByDomainReferenceDnssec_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type DELETE_DomainsByDomainReferenceDnssec_Response_422 = HTTPValidationError
@@ -2585,11 +2459,7 @@ export type DELETE_DomainsByDomainReferenceDnssec_Response_422 = HTTPValidationE
  *
 
  */
-export type GET_DomainsByDomainReferenceDnssec = {
-  200: GET_DomainsByDomainReferenceDnssec_Response_200
-  404: GET_DomainsByDomainReferenceDnssec_Response_404
-  422: GET_DomainsByDomainReferenceDnssec_Response_422
-}
+export type GET_DomainsByDomainReferenceDnssec_Response = GET_DomainsByDomainReferenceDnssec_Response_200 | GET_DomainsByDomainReferenceDnssec_Response_404 | GET_DomainsByDomainReferenceDnssec_Response_422;
 
 /**
  * 200 response for GET DomainsByDomainReferenceDnssec endpoint
@@ -2603,7 +2473,7 @@ export type GET_DomainsByDomainReferenceDnssec = {
  *
  * @path /v1/domains/{domain_reference}/dnssec
  *
- * @see {@link GET_DomainsByDomainReferenceDnssec} - The main response type definition
+ * @see {@link GET_DomainsByDomainReferenceDnssec_Response} - The main response type definition
  * @see {@link DomainDnssecData} - The actual schema type definition
  */
 export type GET_DomainsByDomainReferenceDnssec_Response_200 = DomainDnssecDataArray
@@ -2620,7 +2490,7 @@ export type GET_DomainsByDomainReferenceDnssec_Response_200 = DomainDnssecDataAr
  *
  * @path /v1/domains/{domain_reference}/dnssec
  *
- * @see {@link GET_DomainsByDomainReferenceDnssec} - The main response type definition
+ * @see {@link GET_DomainsByDomainReferenceDnssec_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type GET_DomainsByDomainReferenceDnssec_Response_404 = Problem
@@ -2637,7 +2507,7 @@ export type GET_DomainsByDomainReferenceDnssec_Response_404 = Problem
  *
  * @path /v1/domains/{domain_reference}/dnssec
  *
- * @see {@link GET_DomainsByDomainReferenceDnssec} - The main response type definition
+ * @see {@link GET_DomainsByDomainReferenceDnssec_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type GET_DomainsByDomainReferenceDnssec_Response_422 = HTTPValidationError
@@ -2663,11 +2533,7 @@ export type GET_DomainsByDomainReferenceDnssec_Response_422 = HTTPValidationErro
  *
 
  */
-export type PUT_DomainsByDomainReferenceDnssec = {
-  200: PUT_DomainsByDomainReferenceDnssec_Response_200
-  404: PUT_DomainsByDomainReferenceDnssec_Response_404
-  422: PUT_DomainsByDomainReferenceDnssec_Response_422
-}
+export type PUT_DomainsByDomainReferenceDnssec_Response = PUT_DomainsByDomainReferenceDnssec_Response_200 | PUT_DomainsByDomainReferenceDnssec_Response_404 | PUT_DomainsByDomainReferenceDnssec_Response_422;
 
 /**
  * 200 response for PUT DomainsByDomainReferenceDnssec endpoint
@@ -2681,7 +2547,7 @@ export type PUT_DomainsByDomainReferenceDnssec = {
  *
  * @path /v1/domains/{domain_reference}/dnssec
  *
- * @see {@link PUT_DomainsByDomainReferenceDnssec} - The main response type definition
+ * @see {@link PUT_DomainsByDomainReferenceDnssec_Response} - The main response type definition
  * @see {@link DomainDnssecData} - The actual schema type definition
  */
 export type PUT_DomainsByDomainReferenceDnssec_Response_200 = DomainDnssecDataArray
@@ -2698,7 +2564,7 @@ export type PUT_DomainsByDomainReferenceDnssec_Response_200 = DomainDnssecDataAr
  *
  * @path /v1/domains/{domain_reference}/dnssec
  *
- * @see {@link PUT_DomainsByDomainReferenceDnssec} - The main response type definition
+ * @see {@link PUT_DomainsByDomainReferenceDnssec_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type PUT_DomainsByDomainReferenceDnssec_Response_404 = Problem
@@ -2715,7 +2581,7 @@ export type PUT_DomainsByDomainReferenceDnssec_Response_404 = Problem
  *
  * @path /v1/domains/{domain_reference}/dnssec
  *
- * @see {@link PUT_DomainsByDomainReferenceDnssec} - The main response type definition
+ * @see {@link PUT_DomainsByDomainReferenceDnssec_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type PUT_DomainsByDomainReferenceDnssec_Response_422 = HTTPValidationError
@@ -2741,10 +2607,7 @@ to the current expiration date of the domain.
  *
 
  */
-export type POST_DomainsByDomainReferenceRenew = {
-  200: POST_DomainsByDomainReferenceRenew_Response_200
-  422: POST_DomainsByDomainReferenceRenew_Response_422
-}
+export type POST_DomainsByDomainReferenceRenew_Response = POST_DomainsByDomainReferenceRenew_Response_200 | POST_DomainsByDomainReferenceRenew_Response_422;
 
 /**
  * 200 response for POST DomainsByDomainReferenceRenew endpoint
@@ -2758,7 +2621,7 @@ export type POST_DomainsByDomainReferenceRenew = {
  *
  * @path /v1/domains/{domain_reference}/renew
  *
- * @see {@link POST_DomainsByDomainReferenceRenew} - The main response type definition
+ * @see {@link POST_DomainsByDomainReferenceRenew_Response} - The main response type definition
  * @see {@link DomainRenew} - The actual schema type definition
  */
 export type POST_DomainsByDomainReferenceRenew_Response_200 = DomainRenew
@@ -2775,7 +2638,7 @@ export type POST_DomainsByDomainReferenceRenew_Response_200 = DomainRenew
  *
  * @path /v1/domains/{domain_reference}/renew
  *
- * @see {@link POST_DomainsByDomainReferenceRenew} - The main response type definition
+ * @see {@link POST_DomainsByDomainReferenceRenew_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type POST_DomainsByDomainReferenceRenew_Response_422 = HTTPValidationError
@@ -2801,11 +2664,7 @@ export type POST_DomainsByDomainReferenceRenew_Response_422 = HTTPValidationErro
  *
 
  */
-export type DELETE_DomainsByDomainReferenceTransfer = {
-  404: DELETE_DomainsByDomainReferenceTransfer_Response_404
-  409: DELETE_DomainsByDomainReferenceTransfer_Response_409
-  422: DELETE_DomainsByDomainReferenceTransfer_Response_422
-}
+export type DELETE_DomainsByDomainReferenceTransfer_Response = DELETE_DomainsByDomainReferenceTransfer_Response_404 | DELETE_DomainsByDomainReferenceTransfer_Response_409 | DELETE_DomainsByDomainReferenceTransfer_Response_422;
 
 /**
  * 404 response for DELETE DomainsByDomainReferenceTransfer endpoint
@@ -2819,7 +2678,7 @@ export type DELETE_DomainsByDomainReferenceTransfer = {
  *
  * @path /v1/domains/{domain_reference}/transfer
  *
- * @see {@link DELETE_DomainsByDomainReferenceTransfer} - The main response type definition
+ * @see {@link DELETE_DomainsByDomainReferenceTransfer_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type DELETE_DomainsByDomainReferenceTransfer_Response_404 = Problem
@@ -2836,7 +2695,7 @@ export type DELETE_DomainsByDomainReferenceTransfer_Response_404 = Problem
  *
  * @path /v1/domains/{domain_reference}/transfer
  *
- * @see {@link DELETE_DomainsByDomainReferenceTransfer} - The main response type definition
+ * @see {@link DELETE_DomainsByDomainReferenceTransfer_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type DELETE_DomainsByDomainReferenceTransfer_Response_409 = Problem
@@ -2853,7 +2712,7 @@ export type DELETE_DomainsByDomainReferenceTransfer_Response_409 = Problem
  *
  * @path /v1/domains/{domain_reference}/transfer
  *
- * @see {@link DELETE_DomainsByDomainReferenceTransfer} - The main response type definition
+ * @see {@link DELETE_DomainsByDomainReferenceTransfer_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type DELETE_DomainsByDomainReferenceTransfer_Response_422 = HTTPValidationError
@@ -2880,10 +2739,7 @@ Specify one or more domains to check for availability.
  *
 
  */
-export type GET_DomainsCheck = {
-  200: GET_DomainsCheck_Response_200
-  422: GET_DomainsCheck_Response_422
-}
+export type GET_DomainsCheck_Response = GET_DomainsCheck_Response_200 | GET_DomainsCheck_Response_422;
 
 /**
  * 200 response for GET DomainsCheck endpoint
@@ -2900,7 +2756,7 @@ export type GET_DomainsCheck = {
 Specify one or more domains to check for availability.
 
  *
- * @see {@link GET_DomainsCheck} - The main response type definition
+ * @see {@link GET_DomainsCheck_Response} - The main response type definition
  * @see {@link DomainCheck} - The actual schema type definition
  */
 export type GET_DomainsCheck_Response_200 = DomainCheck
@@ -2920,7 +2776,7 @@ export type GET_DomainsCheck_Response_200 = DomainCheck
 Specify one or more domains to check for availability.
 
  *
- * @see {@link GET_DomainsCheck} - The main response type definition
+ * @see {@link GET_DomainsCheck_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type GET_DomainsCheck_Response_422 = HTTPValidationError
@@ -2944,9 +2800,7 @@ export type GET_DomainsCheck_Response_422 = HTTPValidationError
  *
 
  */
-export type GET_DomainsSummary = {
-  200: GET_DomainsSummary_Response_200
-}
+export type GET_DomainsSummary_Response = GET_DomainsSummary_Response_200;
 
 /**
  * 200 response for GET DomainsSummary endpoint
@@ -2960,7 +2814,7 @@ export type GET_DomainsSummary = {
  *
  * @path /v1/domains/summary
  *
- * @see {@link GET_DomainsSummary} - The main response type definition
+ * @see {@link GET_DomainsSummary_Response} - The main response type definition
  * @see {@link DomainSummary} - The actual schema type definition
  */
 export type GET_DomainsSummary_Response_200 = DomainSummary
@@ -2990,13 +2844,7 @@ This process can take up to 5 days, until the transfer is approved
  *
 
  */
-export type POST_DomainsTransfer = {
-  201: POST_DomainsTransfer_Response_201
-  400: POST_DomainsTransfer_Response_400
-  404: POST_DomainsTransfer_Response_404
-  409: POST_DomainsTransfer_Response_409
-  422: POST_DomainsTransfer_Response_422
-}
+export type POST_DomainsTransfer_Response = POST_DomainsTransfer_Response_201 | POST_DomainsTransfer_Response_400 | POST_DomainsTransfer_Response_404 | POST_DomainsTransfer_Response_409 | POST_DomainsTransfer_Response_422;
 
 /**
  * 201 response for POST DomainsTransfer endpoint
@@ -3010,7 +2858,7 @@ export type POST_DomainsTransfer = {
  *
  * @path /v1/domains/transfer
  *
- * @see {@link POST_DomainsTransfer} - The main response type definition
+ * @see {@link POST_DomainsTransfer_Response} - The main response type definition
  * @see {@link Domain} - The actual schema type definition
  */
 export type POST_DomainsTransfer_Response_201 = Domain
@@ -3027,7 +2875,7 @@ export type POST_DomainsTransfer_Response_201 = Domain
  *
  * @path /v1/domains/transfer
  *
- * @see {@link POST_DomainsTransfer} - The main response type definition
+ * @see {@link POST_DomainsTransfer_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type POST_DomainsTransfer_Response_400 = Problem
@@ -3044,7 +2892,7 @@ export type POST_DomainsTransfer_Response_400 = Problem
  *
  * @path /v1/domains/transfer
  *
- * @see {@link POST_DomainsTransfer} - The main response type definition
+ * @see {@link POST_DomainsTransfer_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type POST_DomainsTransfer_Response_404 = Problem
@@ -3061,7 +2909,7 @@ export type POST_DomainsTransfer_Response_404 = Problem
  *
  * @path /v1/domains/transfer
  *
- * @see {@link POST_DomainsTransfer} - The main response type definition
+ * @see {@link POST_DomainsTransfer_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type POST_DomainsTransfer_Response_409 = Problem
@@ -3078,7 +2926,7 @@ export type POST_DomainsTransfer_Response_409 = Problem
  *
  * @path /v1/domains/transfer
  *
- * @see {@link POST_DomainsTransfer} - The main response type definition
+ * @see {@link POST_DomainsTransfer_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type POST_DomainsTransfer_Response_422 = Problem
@@ -3105,10 +2953,7 @@ export type POST_DomainsTransfer_Response_422 = Problem
  *
 
  */
-export type GET_EmailForwards = {
-  200: GET_EmailForwards_Response_200
-  422: GET_EmailForwards_Response_422
-}
+export type GET_EmailForwards_Response = GET_EmailForwards_Response_200 | GET_EmailForwards_Response_422;
 
 /**
  * 200 response for GET EmailForwards endpoint
@@ -3125,7 +2970,7 @@ export type GET_EmailForwards = {
  * @param source_address (query) - Optional source address to filter the results
  * @param target_address (query) - Optional target address to filter the results
  *
- * @see {@link GET_EmailForwards} - The main response type definition
+ * @see {@link GET_EmailForwards_Response} - The main response type definition
  * @see {@link Pagination_EmailForward} - The actual schema type definition
  */
 export type GET_EmailForwards_Response_200 = Pagination_EmailForward
@@ -3145,7 +2990,7 @@ export type GET_EmailForwards_Response_200 = Pagination_EmailForward
  * @param source_address (query) - Optional source address to filter the results
  * @param target_address (query) - Optional target address to filter the results
  *
- * @see {@link GET_EmailForwards} - The main response type definition
+ * @see {@link GET_EmailForwards_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type GET_EmailForwards_Response_422 = HTTPValidationError
@@ -3169,10 +3014,7 @@ export type GET_EmailForwards_Response_422 = HTTPValidationError
  *
 
  */
-export type POST_EmailForwards = {
-  201: POST_EmailForwards_Response_201
-  422: POST_EmailForwards_Response_422
-}
+export type POST_EmailForwards_Response = POST_EmailForwards_Response_201 | POST_EmailForwards_Response_422;
 
 /**
  * 201 response for POST EmailForwards endpoint
@@ -3186,7 +3028,7 @@ export type POST_EmailForwards = {
  *
  * @path /v1/email-forwards
  *
- * @see {@link POST_EmailForwards} - The main response type definition
+ * @see {@link POST_EmailForwards_Response} - The main response type definition
  * @see {@link EmailForward} - The actual schema type definition
  */
 export type POST_EmailForwards_Response_201 = EmailForward
@@ -3203,7 +3045,7 @@ export type POST_EmailForwards_Response_201 = EmailForward
  *
  * @path /v1/email-forwards
  *
- * @see {@link POST_EmailForwards} - The main response type definition
+ * @see {@link POST_EmailForwards_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type POST_EmailForwards_Response_422 = HTTPValidationError
@@ -3227,10 +3069,7 @@ export type POST_EmailForwards_Response_422 = HTTPValidationError
  *
 
  */
-export type POST_EmailForwardsBulkDelete = {
-  200: POST_EmailForwardsBulkDelete_Response_200
-  422: POST_EmailForwardsBulkDelete_Response_422
-}
+export type POST_EmailForwardsBulkDelete_Response = POST_EmailForwardsBulkDelete_Response_200 | POST_EmailForwardsBulkDelete_Response_422;
 
 /**
  * 200 response for POST EmailForwardsBulkDelete endpoint
@@ -3244,7 +3083,7 @@ export type POST_EmailForwardsBulkDelete = {
  *
  * @path /v1/email-forwards/bulk-delete
  *
- * @see {@link POST_EmailForwardsBulkDelete} - The main response type definition
+ * @see {@link POST_EmailForwardsBulkDelete_Response} - The main response type definition
  * @see {@link EmailForwardBulkDeleteResult} - The actual schema type definition
  */
 export type POST_EmailForwardsBulkDelete_Response_200 = EmailForwardBulkDeleteResult
@@ -3261,7 +3100,7 @@ export type POST_EmailForwardsBulkDelete_Response_200 = EmailForwardBulkDeleteRe
  *
  * @path /v1/email-forwards/bulk-delete
  *
- * @see {@link POST_EmailForwardsBulkDelete} - The main response type definition
+ * @see {@link POST_EmailForwardsBulkDelete_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type POST_EmailForwardsBulkDelete_Response_422 = HTTPValidationError
@@ -3285,10 +3124,7 @@ export type POST_EmailForwardsBulkDelete_Response_422 = HTTPValidationError
  *
 
  */
-export type PATCH_EmailForwardsBulkUpdate = {
-  200: PATCH_EmailForwardsBulkUpdate_Response_200
-  422: PATCH_EmailForwardsBulkUpdate_Response_422
-}
+export type PATCH_EmailForwardsBulkUpdate_Response = PATCH_EmailForwardsBulkUpdate_Response_200 | PATCH_EmailForwardsBulkUpdate_Response_422;
 
 /**
  * 200 response for PATCH EmailForwardsBulkUpdate endpoint
@@ -3302,7 +3138,7 @@ export type PATCH_EmailForwardsBulkUpdate = {
  *
  * @path /v1/email-forwards/bulk-update
  *
- * @see {@link PATCH_EmailForwardsBulkUpdate} - The main response type definition
+ * @see {@link PATCH_EmailForwardsBulkUpdate_Response} - The main response type definition
  * @see {@link EmailForwardBulkUpdateResult} - The actual schema type definition
  */
 export type PATCH_EmailForwardsBulkUpdate_Response_200 = EmailForwardBulkUpdateResult
@@ -3319,7 +3155,7 @@ export type PATCH_EmailForwardsBulkUpdate_Response_200 = EmailForwardBulkUpdateR
  *
  * @path /v1/email-forwards/bulk-update
  *
- * @see {@link PATCH_EmailForwardsBulkUpdate} - The main response type definition
+ * @see {@link PATCH_EmailForwardsBulkUpdate_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type PATCH_EmailForwardsBulkUpdate_Response_422 = HTTPValidationError
@@ -3342,9 +3178,7 @@ export type PATCH_EmailForwardsBulkUpdate_Response_422 = HTTPValidationError
  *
 
  */
-export type DELETE_EmailForwardsByEmailForwardId = {
-  422: DELETE_EmailForwardsByEmailForwardId_Response_422
-}
+export type DELETE_EmailForwardsByEmailForwardId_Response = DELETE_EmailForwardsByEmailForwardId_Response_422;
 
 /**
  * 422 response for DELETE EmailForwardsByEmailForwardId endpoint
@@ -3358,7 +3192,7 @@ export type DELETE_EmailForwardsByEmailForwardId = {
  *
  * @path /v1/email-forwards/{email_forward_id}
  *
- * @see {@link DELETE_EmailForwardsByEmailForwardId} - The main response type definition
+ * @see {@link DELETE_EmailForwardsByEmailForwardId_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type DELETE_EmailForwardsByEmailForwardId_Response_422 = HTTPValidationError
@@ -3382,10 +3216,7 @@ export type DELETE_EmailForwardsByEmailForwardId_Response_422 = HTTPValidationEr
  *
 
  */
-export type GET_EmailForwardsByEmailForwardId = {
-  200: GET_EmailForwardsByEmailForwardId_Response_200
-  422: GET_EmailForwardsByEmailForwardId_Response_422
-}
+export type GET_EmailForwardsByEmailForwardId_Response = GET_EmailForwardsByEmailForwardId_Response_200 | GET_EmailForwardsByEmailForwardId_Response_422;
 
 /**
  * 200 response for GET EmailForwardsByEmailForwardId endpoint
@@ -3399,7 +3230,7 @@ export type GET_EmailForwardsByEmailForwardId = {
  *
  * @path /v1/email-forwards/{email_forward_id}
  *
- * @see {@link GET_EmailForwardsByEmailForwardId} - The main response type definition
+ * @see {@link GET_EmailForwardsByEmailForwardId_Response} - The main response type definition
  * @see {@link EmailForward} - The actual schema type definition
  */
 export type GET_EmailForwardsByEmailForwardId_Response_200 = EmailForward
@@ -3416,7 +3247,7 @@ export type GET_EmailForwardsByEmailForwardId_Response_200 = EmailForward
  *
  * @path /v1/email-forwards/{email_forward_id}
  *
- * @see {@link GET_EmailForwardsByEmailForwardId} - The main response type definition
+ * @see {@link GET_EmailForwardsByEmailForwardId_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type GET_EmailForwardsByEmailForwardId_Response_422 = HTTPValidationError
@@ -3440,10 +3271,7 @@ export type GET_EmailForwardsByEmailForwardId_Response_422 = HTTPValidationError
  *
 
  */
-export type PATCH_EmailForwardsByEmailForwardId = {
-  200: PATCH_EmailForwardsByEmailForwardId_Response_200
-  422: PATCH_EmailForwardsByEmailForwardId_Response_422
-}
+export type PATCH_EmailForwardsByEmailForwardId_Response = PATCH_EmailForwardsByEmailForwardId_Response_200 | PATCH_EmailForwardsByEmailForwardId_Response_422;
 
 /**
  * 200 response for PATCH EmailForwardsByEmailForwardId endpoint
@@ -3457,7 +3285,7 @@ export type PATCH_EmailForwardsByEmailForwardId = {
  *
  * @path /v1/email-forwards/{email_forward_id}
  *
- * @see {@link PATCH_EmailForwardsByEmailForwardId} - The main response type definition
+ * @see {@link PATCH_EmailForwardsByEmailForwardId_Response} - The main response type definition
  * @see {@link EmailForward} - The actual schema type definition
  */
 export type PATCH_EmailForwardsByEmailForwardId_Response_200 = EmailForward
@@ -3474,7 +3302,7 @@ export type PATCH_EmailForwardsByEmailForwardId_Response_200 = EmailForward
  *
  * @path /v1/email-forwards/{email_forward_id}
  *
- * @see {@link PATCH_EmailForwardsByEmailForwardId} - The main response type definition
+ * @see {@link PATCH_EmailForwardsByEmailForwardId_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type PATCH_EmailForwardsByEmailForwardId_Response_422 = HTTPValidationError
@@ -3499,11 +3327,7 @@ export type PATCH_EmailForwardsByEmailForwardId_Response_422 = HTTPValidationErr
  *
 
  */
-export type GET_Event = {
-  200: GET_Event_Response_200
-  401: GET_Event_Response_401
-  422: GET_Event_Response_422
-}
+export type GET_Event_Response = GET_Event_Response_200 | GET_Event_Response_401 | GET_Event_Response_422;
 
 /**
  * 200 response for GET Event endpoint
@@ -3517,7 +3341,7 @@ export type GET_Event = {
  *
  * @path /v1/event
  *
- * @see {@link GET_Event} - The main response type definition
+ * @see {@link GET_Event_Response} - The main response type definition
  * @see {@link Pagination_Event} - The actual schema type definition
  */
 export type GET_Event_Response_200 = Pagination_Event
@@ -3534,7 +3358,7 @@ export type GET_Event_Response_200 = Pagination_Event
  *
  * @path /v1/event
  *
- * @see {@link GET_Event} - The main response type definition
+ * @see {@link GET_Event_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type GET_Event_Response_401 = Problem
@@ -3551,7 +3375,7 @@ export type GET_Event_Response_401 = Problem
  *
  * @path /v1/event
  *
- * @see {@link GET_Event} - The main response type definition
+ * @see {@link GET_Event_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type GET_Event_Response_422 = HTTPValidationError
@@ -3577,12 +3401,7 @@ export type GET_Event_Response_422 = HTTPValidationError
  *
 
  */
-export type GET_EventByEventId = {
-  200: GET_EventByEventId_Response_200
-  401: GET_EventByEventId_Response_401
-  404: GET_EventByEventId_Response_404
-  422: GET_EventByEventId_Response_422
-}
+export type GET_EventByEventId_Response = GET_EventByEventId_Response_200 | GET_EventByEventId_Response_401 | GET_EventByEventId_Response_404 | GET_EventByEventId_Response_422;
 
 /**
  * 200 response for GET EventByEventId endpoint
@@ -3596,7 +3415,7 @@ export type GET_EventByEventId = {
  *
  * @path /v1/event/{event_id}
  *
- * @see {@link GET_EventByEventId} - The main response type definition
+ * @see {@link GET_EventByEventId_Response} - The main response type definition
  * @see {@link EventSchema} - The actual schema type definition
  */
 export type GET_EventByEventId_Response_200 = EventSchema
@@ -3613,7 +3432,7 @@ export type GET_EventByEventId_Response_200 = EventSchema
  *
  * @path /v1/event/{event_id}
  *
- * @see {@link GET_EventByEventId} - The main response type definition
+ * @see {@link GET_EventByEventId_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type GET_EventByEventId_Response_401 = Problem
@@ -3630,7 +3449,7 @@ export type GET_EventByEventId_Response_401 = Problem
  *
  * @path /v1/event/{event_id}
  *
- * @see {@link GET_EventByEventId} - The main response type definition
+ * @see {@link GET_EventByEventId_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type GET_EventByEventId_Response_404 = Problem
@@ -3647,7 +3466,7 @@ export type GET_EventByEventId_Response_404 = Problem
  *
  * @path /v1/event/{event_id}
  *
- * @see {@link GET_EventByEventId} - The main response type definition
+ * @see {@link GET_EventByEventId_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type GET_EventByEventId_Response_422 = HTTPValidationError
@@ -3672,11 +3491,7 @@ export type GET_EventByEventId_Response_422 = HTTPValidationError
  *
 
  */
-export type PATCH_EventByEventId = {
-  401: PATCH_EventByEventId_Response_401
-  404: PATCH_EventByEventId_Response_404
-  422: PATCH_EventByEventId_Response_422
-}
+export type PATCH_EventByEventId_Response = PATCH_EventByEventId_Response_401 | PATCH_EventByEventId_Response_404 | PATCH_EventByEventId_Response_422;
 
 /**
  * 401 response for PATCH EventByEventId endpoint
@@ -3690,7 +3505,7 @@ export type PATCH_EventByEventId = {
  *
  * @path /v1/event/{event_id}
  *
- * @see {@link PATCH_EventByEventId} - The main response type definition
+ * @see {@link PATCH_EventByEventId_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type PATCH_EventByEventId_Response_401 = Problem
@@ -3707,7 +3522,7 @@ export type PATCH_EventByEventId_Response_401 = Problem
  *
  * @path /v1/event/{event_id}
  *
- * @see {@link PATCH_EventByEventId} - The main response type definition
+ * @see {@link PATCH_EventByEventId_Response} - The main response type definition
  * @see {@link Problem} - The actual schema type definition
  */
 export type PATCH_EventByEventId_Response_404 = Problem
@@ -3724,7 +3539,7 @@ export type PATCH_EventByEventId_Response_404 = Problem
  *
  * @path /v1/event/{event_id}
  *
- * @see {@link PATCH_EventByEventId} - The main response type definition
+ * @see {@link PATCH_EventByEventId_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type PATCH_EventByEventId_Response_422 = HTTPValidationError
@@ -3748,10 +3563,7 @@ export type PATCH_EventByEventId_Response_422 = HTTPValidationError
  *
 
  */
-export type GET_Notifications = {
-  200: GET_Notifications_Response_200
-  422: GET_Notifications_Response_422
-}
+export type GET_Notifications_Response = GET_Notifications_Response_200 | GET_Notifications_Response_422;
 
 /**
  * 200 response for GET Notifications endpoint
@@ -3765,7 +3577,7 @@ export type GET_Notifications = {
  *
  * @path /v1/notifications
  *
- * @see {@link GET_Notifications} - The main response type definition
+ * @see {@link GET_Notifications_Response} - The main response type definition
  * @see {@link Pagination_UserNotificationSummary} - The actual schema type definition
  */
 export type GET_Notifications_Response_200 = Pagination_UserNotificationSummary
@@ -3782,7 +3594,7 @@ export type GET_Notifications_Response_200 = Pagination_UserNotificationSummary
  *
  * @path /v1/notifications
  *
- * @see {@link GET_Notifications} - The main response type definition
+ * @see {@link GET_Notifications_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type GET_Notifications_Response_422 = HTTPValidationError
@@ -3806,10 +3618,7 @@ export type GET_Notifications_Response_422 = HTTPValidationError
  *
 
  */
-export type POST_Notifications = {
-  201: POST_Notifications_Response_201
-  422: POST_Notifications_Response_422
-}
+export type POST_Notifications_Response = POST_Notifications_Response_201 | POST_Notifications_Response_422;
 
 /**
  * 201 response for POST Notifications endpoint
@@ -3823,7 +3632,7 @@ export type POST_Notifications = {
  *
  * @path /v1/notifications
  *
- * @see {@link POST_Notifications} - The main response type definition
+ * @see {@link POST_Notifications_Response} - The main response type definition
  * @see {@link Notification} - The actual schema type definition
  */
 export type POST_Notifications_Response_201 = Notification
@@ -3840,7 +3649,7 @@ export type POST_Notifications_Response_201 = Notification
  *
  * @path /v1/notifications
  *
- * @see {@link POST_Notifications} - The main response type definition
+ * @see {@link POST_Notifications_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type POST_Notifications_Response_422 = HTTPValidationError
@@ -3863,9 +3672,7 @@ export type POST_Notifications_Response_422 = HTTPValidationError
  *
 
  */
-export type DELETE_NotificationsByNotificationId = {
-  422: DELETE_NotificationsByNotificationId_Response_422
-}
+export type DELETE_NotificationsByNotificationId_Response = DELETE_NotificationsByNotificationId_Response_422;
 
 /**
  * 422 response for DELETE NotificationsByNotificationId endpoint
@@ -3879,7 +3686,7 @@ export type DELETE_NotificationsByNotificationId = {
  *
  * @path /v1/notifications/{notification_id}
  *
- * @see {@link DELETE_NotificationsByNotificationId} - The main response type definition
+ * @see {@link DELETE_NotificationsByNotificationId_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type DELETE_NotificationsByNotificationId_Response_422 = HTTPValidationError
@@ -3903,10 +3710,7 @@ export type DELETE_NotificationsByNotificationId_Response_422 = HTTPValidationEr
  *
 
  */
-export type GET_NotificationsByNotificationId = {
-  200: GET_NotificationsByNotificationId_Response_200
-  422: GET_NotificationsByNotificationId_Response_422
-}
+export type GET_NotificationsByNotificationId_Response = GET_NotificationsByNotificationId_Response_200 | GET_NotificationsByNotificationId_Response_422;
 
 /**
  * 200 response for GET NotificationsByNotificationId endpoint
@@ -3920,7 +3724,7 @@ export type GET_NotificationsByNotificationId = {
  *
  * @path /v1/notifications/{notification_id}
  *
- * @see {@link GET_NotificationsByNotificationId} - The main response type definition
+ * @see {@link GET_NotificationsByNotificationId_Response} - The main response type definition
  * @see {@link UserNotification} - The actual schema type definition
  */
 export type GET_NotificationsByNotificationId_Response_200 = UserNotification
@@ -3937,7 +3741,7 @@ export type GET_NotificationsByNotificationId_Response_200 = UserNotification
  *
  * @path /v1/notifications/{notification_id}
  *
- * @see {@link GET_NotificationsByNotificationId} - The main response type definition
+ * @see {@link GET_NotificationsByNotificationId_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type GET_NotificationsByNotificationId_Response_422 = HTTPValidationError
@@ -3961,10 +3765,7 @@ export type GET_NotificationsByNotificationId_Response_422 = HTTPValidationError
  *
 
  */
-export type PUT_NotificationsByNotificationId = {
-  200: PUT_NotificationsByNotificationId_Response_200
-  422: PUT_NotificationsByNotificationId_Response_422
-}
+export type PUT_NotificationsByNotificationId_Response = PUT_NotificationsByNotificationId_Response_200 | PUT_NotificationsByNotificationId_Response_422;
 
 /**
  * 200 response for PUT NotificationsByNotificationId endpoint
@@ -3978,7 +3779,7 @@ export type PUT_NotificationsByNotificationId = {
  *
  * @path /v1/notifications/{notification_id}
  *
- * @see {@link PUT_NotificationsByNotificationId} - The main response type definition
+ * @see {@link PUT_NotificationsByNotificationId_Response} - The main response type definition
  * @see {@link Notification} - The actual schema type definition
  */
 export type PUT_NotificationsByNotificationId_Response_200 = Notification
@@ -3995,7 +3796,7 @@ export type PUT_NotificationsByNotificationId_Response_200 = Notification
  *
  * @path /v1/notifications/{notification_id}
  *
- * @see {@link PUT_NotificationsByNotificationId} - The main response type definition
+ * @see {@link PUT_NotificationsByNotificationId_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type PUT_NotificationsByNotificationId_Response_422 = HTTPValidationError
@@ -4018,9 +3819,7 @@ export type PUT_NotificationsByNotificationId_Response_422 = HTTPValidationError
  *
 
  */
-export type PATCH_NotificationsByNotificationIdRead = {
-  422: PATCH_NotificationsByNotificationIdRead_Response_422
-}
+export type PATCH_NotificationsByNotificationIdRead_Response = PATCH_NotificationsByNotificationIdRead_Response_422;
 
 /**
  * 422 response for PATCH NotificationsByNotificationIdRead endpoint
@@ -4034,7 +3833,7 @@ export type PATCH_NotificationsByNotificationIdRead = {
  *
  * @path /v1/notifications/{notification_id}/read
  *
- * @see {@link PATCH_NotificationsByNotificationIdRead} - The main response type definition
+ * @see {@link PATCH_NotificationsByNotificationIdRead_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type PATCH_NotificationsByNotificationIdRead_Response_422 = HTTPValidationError
@@ -4058,10 +3857,7 @@ export type PATCH_NotificationsByNotificationIdRead_Response_422 = HTTPValidatio
  *
 
  */
-export type GET_Organizations = {
-  200: GET_Organizations_Response_200
-  422: GET_Organizations_Response_422
-}
+export type GET_Organizations_Response = GET_Organizations_Response_200 | GET_Organizations_Response_422;
 
 /**
  * 200 response for GET Organizations endpoint
@@ -4075,7 +3871,7 @@ export type GET_Organizations = {
  *
  * @path /v1/organizations
  *
- * @see {@link GET_Organizations} - The main response type definition
+ * @see {@link GET_Organizations_Response} - The main response type definition
  * @see {@link Pagination_Organization} - The actual schema type definition
  */
 export type GET_Organizations_Response_200 = Pagination_Organization
@@ -4092,7 +3888,7 @@ export type GET_Organizations_Response_200 = Pagination_Organization
  *
  * @path /v1/organizations
  *
- * @see {@link GET_Organizations} - The main response type definition
+ * @see {@link GET_Organizations_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type GET_Organizations_Response_422 = HTTPValidationError
@@ -4116,10 +3912,7 @@ export type GET_Organizations_Response_422 = HTTPValidationError
  *
 
  */
-export type POST_Organizations = {
-  200: POST_Organizations_Response_200
-  422: POST_Organizations_Response_422
-}
+export type POST_Organizations_Response = POST_Organizations_Response_200 | POST_Organizations_Response_422;
 
 /**
  * 200 response for POST Organizations endpoint
@@ -4133,7 +3926,7 @@ export type POST_Organizations = {
  *
  * @path /v1/organizations
  *
- * @see {@link POST_Organizations} - The main response type definition
+ * @see {@link POST_Organizations_Response} - The main response type definition
  * @see {@link Organization} - The actual schema type definition
  */
 export type POST_Organizations_Response_200 = Organization
@@ -4150,7 +3943,7 @@ export type POST_Organizations_Response_200 = Organization
  *
  * @path /v1/organizations
  *
- * @see {@link POST_Organizations} - The main response type definition
+ * @see {@link POST_Organizations_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type POST_Organizations_Response_422 = HTTPValidationError
@@ -4175,10 +3968,7 @@ export type POST_Organizations_Response_422 = HTTPValidationError
  *
 
  */
-export type GET_OrganizationsAttributes = {
-  200: GET_OrganizationsAttributes_Response_200
-  422: GET_OrganizationsAttributes_Response_422
-}
+export type GET_OrganizationsAttributes_Response = GET_OrganizationsAttributes_Response_200 | GET_OrganizationsAttributes_Response_422;
 
 /**
  * 200 response for GET OrganizationsAttributes endpoint
@@ -4193,7 +3983,7 @@ export type GET_OrganizationsAttributes = {
  * @path /v1/organizations/attributes
  * @param keys (query) - Optional list of attribute keys to filter
  *
- * @see {@link GET_OrganizationsAttributes} - The main response type definition
+ * @see {@link GET_OrganizationsAttributes_Response} - The main response type definition
  * @see {@link OrganizationAttribute2} - The actual schema type definition
  */
 export type GET_OrganizationsAttributes_Response_200 = OrganizationAttribute2Array
@@ -4211,7 +4001,7 @@ export type GET_OrganizationsAttributes_Response_200 = OrganizationAttribute2Arr
  * @path /v1/organizations/attributes
  * @param keys (query) - Optional list of attribute keys to filter
  *
- * @see {@link GET_OrganizationsAttributes} - The main response type definition
+ * @see {@link GET_OrganizationsAttributes_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type GET_OrganizationsAttributes_Response_422 = HTTPValidationError
@@ -4235,10 +4025,7 @@ export type GET_OrganizationsAttributes_Response_422 = HTTPValidationError
  *
 
  */
-export type PATCH_OrganizationsAttributes = {
-  200: PATCH_OrganizationsAttributes_Response_200
-  422: PATCH_OrganizationsAttributes_Response_422
-}
+export type PATCH_OrganizationsAttributes_Response = PATCH_OrganizationsAttributes_Response_200 | PATCH_OrganizationsAttributes_Response_422;
 
 /**
  * 200 response for PATCH OrganizationsAttributes endpoint
@@ -4252,7 +4039,7 @@ export type PATCH_OrganizationsAttributes = {
  *
  * @path /v1/organizations/attributes
  *
- * @see {@link PATCH_OrganizationsAttributes} - The main response type definition
+ * @see {@link PATCH_OrganizationsAttributes_Response} - The main response type definition
  * @see {@link OrganizationAttribute2} - The actual schema type definition
  */
 export type PATCH_OrganizationsAttributes_Response_200 = OrganizationAttribute2Array
@@ -4269,7 +4056,7 @@ export type PATCH_OrganizationsAttributes_Response_200 = OrganizationAttribute2A
  *
  * @path /v1/organizations/attributes
  *
- * @see {@link PATCH_OrganizationsAttributes} - The main response type definition
+ * @see {@link PATCH_OrganizationsAttributes_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type PATCH_OrganizationsAttributes_Response_422 = HTTPValidationError
@@ -4294,10 +4081,7 @@ export type PATCH_OrganizationsAttributes_Response_422 = HTTPValidationError
  *
 
  */
-export type GET_OrganizationsAttributesByOrganizationId = {
-  200: GET_OrganizationsAttributesByOrganizationId_Response_200
-  422: GET_OrganizationsAttributesByOrganizationId_Response_422
-}
+export type GET_OrganizationsAttributesByOrganizationId_Response = GET_OrganizationsAttributesByOrganizationId_Response_200 | GET_OrganizationsAttributesByOrganizationId_Response_422;
 
 /**
  * 200 response for GET OrganizationsAttributesByOrganizationId endpoint
@@ -4312,7 +4096,7 @@ export type GET_OrganizationsAttributesByOrganizationId = {
  * @path /v1/organizations/attributes/{organization_id}
  * @param keys (query) - Optional list of attribute keys to filter
  *
- * @see {@link GET_OrganizationsAttributesByOrganizationId} - The main response type definition
+ * @see {@link GET_OrganizationsAttributesByOrganizationId_Response} - The main response type definition
  * @see {@link OrganizationAttribute2} - The actual schema type definition
  */
 export type GET_OrganizationsAttributesByOrganizationId_Response_200 = OrganizationAttribute2Array
@@ -4330,7 +4114,7 @@ export type GET_OrganizationsAttributesByOrganizationId_Response_200 = Organizat
  * @path /v1/organizations/attributes/{organization_id}
  * @param keys (query) - Optional list of attribute keys to filter
  *
- * @see {@link GET_OrganizationsAttributesByOrganizationId} - The main response type definition
+ * @see {@link GET_OrganizationsAttributesByOrganizationId_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type GET_OrganizationsAttributesByOrganizationId_Response_422 = HTTPValidationError
@@ -4354,10 +4138,7 @@ export type GET_OrganizationsAttributesByOrganizationId_Response_422 = HTTPValid
  *
 
  */
-export type PATCH_OrganizationsAttributesByOrganizationId = {
-  200: PATCH_OrganizationsAttributesByOrganizationId_Response_200
-  422: PATCH_OrganizationsAttributesByOrganizationId_Response_422
-}
+export type PATCH_OrganizationsAttributesByOrganizationId_Response = PATCH_OrganizationsAttributesByOrganizationId_Response_200 | PATCH_OrganizationsAttributesByOrganizationId_Response_422;
 
 /**
  * 200 response for PATCH OrganizationsAttributesByOrganizationId endpoint
@@ -4371,7 +4152,7 @@ export type PATCH_OrganizationsAttributesByOrganizationId = {
  *
  * @path /v1/organizations/attributes/{organization_id}
  *
- * @see {@link PATCH_OrganizationsAttributesByOrganizationId} - The main response type definition
+ * @see {@link PATCH_OrganizationsAttributesByOrganizationId_Response} - The main response type definition
  * @see {@link OrganizationAttribute2} - The actual schema type definition
  */
 export type PATCH_OrganizationsAttributesByOrganizationId_Response_200 = OrganizationAttribute2Array
@@ -4388,7 +4169,7 @@ export type PATCH_OrganizationsAttributesByOrganizationId_Response_200 = Organiz
  *
  * @path /v1/organizations/attributes/{organization_id}
  *
- * @see {@link PATCH_OrganizationsAttributesByOrganizationId} - The main response type definition
+ * @see {@link PATCH_OrganizationsAttributesByOrganizationId_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type PATCH_OrganizationsAttributesByOrganizationId_Response_422 = HTTPValidationError
@@ -4411,9 +4192,7 @@ export type PATCH_OrganizationsAttributesByOrganizationId_Response_422 = HTTPVal
  *
 
  */
-export type DELETE_OrganizationsByOrganizationId = {
-  422: DELETE_OrganizationsByOrganizationId_Response_422
-}
+export type DELETE_OrganizationsByOrganizationId_Response = DELETE_OrganizationsByOrganizationId_Response_422;
 
 /**
  * 422 response for DELETE OrganizationsByOrganizationId endpoint
@@ -4427,7 +4206,7 @@ export type DELETE_OrganizationsByOrganizationId = {
  *
  * @path /v1/organizations/{organization_id}
  *
- * @see {@link DELETE_OrganizationsByOrganizationId} - The main response type definition
+ * @see {@link DELETE_OrganizationsByOrganizationId_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type DELETE_OrganizationsByOrganizationId_Response_422 = HTTPValidationError
@@ -4451,10 +4230,7 @@ export type DELETE_OrganizationsByOrganizationId_Response_422 = HTTPValidationEr
  *
 
  */
-export type GET_OrganizationsByOrganizationId = {
-  200: GET_OrganizationsByOrganizationId_Response_200
-  422: GET_OrganizationsByOrganizationId_Response_422
-}
+export type GET_OrganizationsByOrganizationId_Response = GET_OrganizationsByOrganizationId_Response_200 | GET_OrganizationsByOrganizationId_Response_422;
 
 /**
  * 200 response for GET OrganizationsByOrganizationId endpoint
@@ -4468,7 +4244,7 @@ export type GET_OrganizationsByOrganizationId = {
  *
  * @path /v1/organizations/{organization_id}
  *
- * @see {@link GET_OrganizationsByOrganizationId} - The main response type definition
+ * @see {@link GET_OrganizationsByOrganizationId_Response} - The main response type definition
  * @see {@link OrganizationWithPlan} - The actual schema type definition
  */
 export type GET_OrganizationsByOrganizationId_Response_200 = OrganizationWithPlan
@@ -4485,7 +4261,7 @@ export type GET_OrganizationsByOrganizationId_Response_200 = OrganizationWithPla
  *
  * @path /v1/organizations/{organization_id}
  *
- * @see {@link GET_OrganizationsByOrganizationId} - The main response type definition
+ * @see {@link GET_OrganizationsByOrganizationId_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type GET_OrganizationsByOrganizationId_Response_422 = HTTPValidationError
@@ -4509,10 +4285,7 @@ export type GET_OrganizationsByOrganizationId_Response_422 = HTTPValidationError
  *
 
  */
-export type PATCH_OrganizationsByOrganizationId = {
-  200: PATCH_OrganizationsByOrganizationId_Response_200
-  422: PATCH_OrganizationsByOrganizationId_Response_422
-}
+export type PATCH_OrganizationsByOrganizationId_Response = PATCH_OrganizationsByOrganizationId_Response_200 | PATCH_OrganizationsByOrganizationId_Response_422;
 
 /**
  * 200 response for PATCH OrganizationsByOrganizationId endpoint
@@ -4526,7 +4299,7 @@ export type PATCH_OrganizationsByOrganizationId = {
  *
  * @path /v1/organizations/{organization_id}
  *
- * @see {@link PATCH_OrganizationsByOrganizationId} - The main response type definition
+ * @see {@link PATCH_OrganizationsByOrganizationId_Response} - The main response type definition
  * @see {@link Organization} - The actual schema type definition
  */
 export type PATCH_OrganizationsByOrganizationId_Response_200 = Organization
@@ -4543,7 +4316,7 @@ export type PATCH_OrganizationsByOrganizationId_Response_200 = Organization
  *
  * @path /v1/organizations/{organization_id}
  *
- * @see {@link PATCH_OrganizationsByOrganizationId} - The main response type definition
+ * @see {@link PATCH_OrganizationsByOrganizationId_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type PATCH_OrganizationsByOrganizationId_Response_422 = HTTPValidationError
@@ -4567,10 +4340,7 @@ export type PATCH_OrganizationsByOrganizationId_Response_422 = HTTPValidationErr
  *
 
  */
-export type PATCH_OrganizationsByOrganizationIdPlan = {
-  200: PATCH_OrganizationsByOrganizationIdPlan_Response_200
-  422: PATCH_OrganizationsByOrganizationIdPlan_Response_422
-}
+export type PATCH_OrganizationsByOrganizationIdPlan_Response = PATCH_OrganizationsByOrganizationIdPlan_Response_200 | PATCH_OrganizationsByOrganizationIdPlan_Response_422;
 
 /**
  * 200 response for PATCH OrganizationsByOrganizationIdPlan endpoint
@@ -4584,7 +4354,7 @@ export type PATCH_OrganizationsByOrganizationIdPlan = {
  *
  * @path /v1/organizations/{organization_id}/plan
  *
- * @see {@link PATCH_OrganizationsByOrganizationIdPlan} - The main response type definition
+ * @see {@link PATCH_OrganizationsByOrganizationIdPlan_Response} - The main response type definition
  * @see {@link OrganizationWithPlan} - The actual schema type definition
  */
 export type PATCH_OrganizationsByOrganizationIdPlan_Response_200 = OrganizationWithPlan
@@ -4601,7 +4371,7 @@ export type PATCH_OrganizationsByOrganizationIdPlan_Response_200 = OrganizationW
  *
  * @path /v1/organizations/{organization_id}/plan
  *
- * @see {@link PATCH_OrganizationsByOrganizationIdPlan} - The main response type definition
+ * @see {@link PATCH_OrganizationsByOrganizationIdPlan_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type PATCH_OrganizationsByOrganizationIdPlan_Response_422 = HTTPValidationError
@@ -4625,9 +4395,7 @@ export type PATCH_OrganizationsByOrganizationIdPlan_Response_422 = HTTPValidatio
  *
 
  */
-export type GET_OrganizationsIpRestrictions = {
-  200: GET_OrganizationsIpRestrictions_Response_200
-}
+export type GET_OrganizationsIpRestrictions_Response = GET_OrganizationsIpRestrictions_Response_200;
 
 /**
  * 200 response for GET OrganizationsIpRestrictions endpoint
@@ -4641,7 +4409,7 @@ export type GET_OrganizationsIpRestrictions = {
  *
  * @path /v1/organizations/ip-restrictions
  *
- * @see {@link GET_OrganizationsIpRestrictions} - The main response type definition
+ * @see {@link GET_OrganizationsIpRestrictions_Response} - The main response type definition
  * @see {@link IpRestriction} - The actual schema type definition
  */
 export type GET_OrganizationsIpRestrictions_Response_200 = IpRestrictionArray
@@ -4666,10 +4434,7 @@ export type GET_OrganizationsIpRestrictions_Response_200 = IpRestrictionArray
  *
 
  */
-export type POST_OrganizationsIpRestrictions = {
-  200: POST_OrganizationsIpRestrictions_Response_200
-  422: POST_OrganizationsIpRestrictions_Response_422
-}
+export type POST_OrganizationsIpRestrictions_Response = POST_OrganizationsIpRestrictions_Response_200 | POST_OrganizationsIpRestrictions_Response_422;
 
 /**
  * 200 response for POST OrganizationsIpRestrictions endpoint
@@ -4683,7 +4448,7 @@ export type POST_OrganizationsIpRestrictions = {
  *
  * @path /v1/organizations/ip-restrictions
  *
- * @see {@link POST_OrganizationsIpRestrictions} - The main response type definition
+ * @see {@link POST_OrganizationsIpRestrictions_Response} - The main response type definition
  * @see {@link IpRestriction} - The actual schema type definition
  */
 export type POST_OrganizationsIpRestrictions_Response_200 = IpRestriction
@@ -4700,7 +4465,7 @@ export type POST_OrganizationsIpRestrictions_Response_200 = IpRestriction
  *
  * @path /v1/organizations/ip-restrictions
  *
- * @see {@link POST_OrganizationsIpRestrictions} - The main response type definition
+ * @see {@link POST_OrganizationsIpRestrictions_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type POST_OrganizationsIpRestrictions_Response_422 = HTTPValidationError
@@ -4724,9 +4489,7 @@ export type POST_OrganizationsIpRestrictions_Response_422 = HTTPValidationError
  *
 
  */
-export type DELETE_OrganizationsIpRestrictionsByIpRestrictionId = {
-  422: DELETE_OrganizationsIpRestrictionsByIpRestrictionId_Response_422
-}
+export type DELETE_OrganizationsIpRestrictionsByIpRestrictionId_Response = DELETE_OrganizationsIpRestrictionsByIpRestrictionId_Response_422;
 
 /**
  * 422 response for DELETE OrganizationsIpRestrictionsByIpRestrictionId endpoint
@@ -4740,7 +4503,7 @@ export type DELETE_OrganizationsIpRestrictionsByIpRestrictionId = {
  *
  * @path /v1/organizations/ip-restrictions/{ip_restriction_id}
  *
- * @see {@link DELETE_OrganizationsIpRestrictionsByIpRestrictionId} - The main response type definition
+ * @see {@link DELETE_OrganizationsIpRestrictionsByIpRestrictionId_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type DELETE_OrganizationsIpRestrictionsByIpRestrictionId_Response_422 = HTTPValidationError
@@ -4765,10 +4528,7 @@ export type DELETE_OrganizationsIpRestrictionsByIpRestrictionId_Response_422 = H
  *
 
  */
-export type GET_OrganizationsIpRestrictionsByIpRestrictionId = {
-  200: GET_OrganizationsIpRestrictionsByIpRestrictionId_Response_200
-  422: GET_OrganizationsIpRestrictionsByIpRestrictionId_Response_422
-}
+export type GET_OrganizationsIpRestrictionsByIpRestrictionId_Response = GET_OrganizationsIpRestrictionsByIpRestrictionId_Response_200 | GET_OrganizationsIpRestrictionsByIpRestrictionId_Response_422;
 
 /**
  * 200 response for GET OrganizationsIpRestrictionsByIpRestrictionId endpoint
@@ -4782,7 +4542,7 @@ export type GET_OrganizationsIpRestrictionsByIpRestrictionId = {
  *
  * @path /v1/organizations/ip-restrictions/{ip_restriction_id}
  *
- * @see {@link GET_OrganizationsIpRestrictionsByIpRestrictionId} - The main response type definition
+ * @see {@link GET_OrganizationsIpRestrictionsByIpRestrictionId_Response} - The main response type definition
  * @see {@link IpRestriction} - The actual schema type definition
  */
 export type GET_OrganizationsIpRestrictionsByIpRestrictionId_Response_200 = IpRestriction
@@ -4799,7 +4559,7 @@ export type GET_OrganizationsIpRestrictionsByIpRestrictionId_Response_200 = IpRe
  *
  * @path /v1/organizations/ip-restrictions/{ip_restriction_id}
  *
- * @see {@link GET_OrganizationsIpRestrictionsByIpRestrictionId} - The main response type definition
+ * @see {@link GET_OrganizationsIpRestrictionsByIpRestrictionId_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type GET_OrganizationsIpRestrictionsByIpRestrictionId_Response_422 = HTTPValidationError
@@ -4824,10 +4584,7 @@ export type GET_OrganizationsIpRestrictionsByIpRestrictionId_Response_422 = HTTP
  *
 
  */
-export type PATCH_OrganizationsIpRestrictionsByIpRestrictionId = {
-  200: PATCH_OrganizationsIpRestrictionsByIpRestrictionId_Response_200
-  422: PATCH_OrganizationsIpRestrictionsByIpRestrictionId_Response_422
-}
+export type PATCH_OrganizationsIpRestrictionsByIpRestrictionId_Response = PATCH_OrganizationsIpRestrictionsByIpRestrictionId_Response_200 | PATCH_OrganizationsIpRestrictionsByIpRestrictionId_Response_422;
 
 /**
  * 200 response for PATCH OrganizationsIpRestrictionsByIpRestrictionId endpoint
@@ -4841,7 +4598,7 @@ export type PATCH_OrganizationsIpRestrictionsByIpRestrictionId = {
  *
  * @path /v1/organizations/ip-restrictions/{ip_restriction_id}
  *
- * @see {@link PATCH_OrganizationsIpRestrictionsByIpRestrictionId} - The main response type definition
+ * @see {@link PATCH_OrganizationsIpRestrictionsByIpRestrictionId_Response} - The main response type definition
  * @see {@link IpRestriction} - The actual schema type definition
  */
 export type PATCH_OrganizationsIpRestrictionsByIpRestrictionId_Response_200 = IpRestriction
@@ -4858,7 +4615,7 @@ export type PATCH_OrganizationsIpRestrictionsByIpRestrictionId_Response_200 = Ip
  *
  * @path /v1/organizations/ip-restrictions/{ip_restriction_id}
  *
- * @see {@link PATCH_OrganizationsIpRestrictionsByIpRestrictionId} - The main response type definition
+ * @see {@link PATCH_OrganizationsIpRestrictionsByIpRestrictionId_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type PATCH_OrganizationsIpRestrictionsByIpRestrictionId_Response_422 = HTTPValidationError
@@ -4881,8 +4638,7 @@ export type PATCH_OrganizationsIpRestrictionsByIpRestrictionId_Response_422 = HT
  *
 
  */
-export type GET_OrganizationsRoles = {
-}
+export type GET_OrganizationsRoles_Response = ;
 
 /**
  * Response types for GET OrganizationsUsers endpoint
@@ -4903,10 +4659,7 @@ export type GET_OrganizationsRoles = {
  *
 
  */
-export type GET_OrganizationsUsers = {
-  200: GET_OrganizationsUsers_Response_200
-  422: GET_OrganizationsUsers_Response_422
-}
+export type GET_OrganizationsUsers_Response = GET_OrganizationsUsers_Response_200 | GET_OrganizationsUsers_Response_422;
 
 /**
  * 200 response for GET OrganizationsUsers endpoint
@@ -4920,7 +4673,7 @@ export type GET_OrganizationsUsers = {
  *
  * @path /v1/organizations/users
  *
- * @see {@link GET_OrganizationsUsers} - The main response type definition
+ * @see {@link GET_OrganizationsUsers_Response} - The main response type definition
  * @see {@link Pagination_User} - The actual schema type definition
  */
 export type GET_OrganizationsUsers_Response_200 = Pagination_User
@@ -4937,7 +4690,7 @@ export type GET_OrganizationsUsers_Response_200 = Pagination_User
  *
  * @path /v1/organizations/users
  *
- * @see {@link GET_OrganizationsUsers} - The main response type definition
+ * @see {@link GET_OrganizationsUsers_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type GET_OrganizationsUsers_Response_422 = HTTPValidationError
@@ -4961,10 +4714,7 @@ export type GET_OrganizationsUsers_Response_422 = HTTPValidationError
  *
 
  */
-export type POST_Users = {
-  200: POST_Users_Response_200
-  422: POST_Users_Response_422
-}
+export type POST_Users_Response = POST_Users_Response_200 | POST_Users_Response_422;
 
 /**
  * 200 response for POST Users endpoint
@@ -4978,7 +4728,7 @@ export type POST_Users = {
  *
  * @path /v1/users
  *
- * @see {@link POST_Users} - The main response type definition
+ * @see {@link POST_Users_Response} - The main response type definition
  * @see {@link User} - The actual schema type definition
  */
 export type POST_Users_Response_200 = User
@@ -4995,7 +4745,7 @@ export type POST_Users_Response_200 = User
  *
  * @path /v1/users
  *
- * @see {@link POST_Users} - The main response type definition
+ * @see {@link POST_Users_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type POST_Users_Response_422 = HTTPValidationError
@@ -5018,9 +4768,7 @@ export type POST_Users_Response_422 = HTTPValidationError
  *
 
  */
-export type POST_UsersAcceptTos = {
-  422: POST_UsersAcceptTos_Response_422
-}
+export type POST_UsersAcceptTos_Response = POST_UsersAcceptTos_Response_422;
 
 /**
  * 422 response for POST UsersAcceptTos endpoint
@@ -5034,7 +4782,7 @@ export type POST_UsersAcceptTos = {
  *
  * @path /v1/users/accept-tos
  *
- * @see {@link POST_UsersAcceptTos} - The main response type definition
+ * @see {@link POST_UsersAcceptTos_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type POST_UsersAcceptTos_Response_422 = HTTPValidationError
@@ -5057,9 +4805,7 @@ export type POST_UsersAcceptTos_Response_422 = HTTPValidationError
  *
 
  */
-export type DELETE_UsersByUserId = {
-  422: DELETE_UsersByUserId_Response_422
-}
+export type DELETE_UsersByUserId_Response = DELETE_UsersByUserId_Response_422;
 
 /**
  * 422 response for DELETE UsersByUserId endpoint
@@ -5073,7 +4819,7 @@ export type DELETE_UsersByUserId = {
  *
  * @path /v1/users/{user_id}
  *
- * @see {@link DELETE_UsersByUserId} - The main response type definition
+ * @see {@link DELETE_UsersByUserId_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type DELETE_UsersByUserId_Response_422 = HTTPValidationError
@@ -5097,10 +4843,7 @@ export type DELETE_UsersByUserId_Response_422 = HTTPValidationError
  *
 
  */
-export type GET_UsersByUserId = {
-  200: GET_UsersByUserId_Response_200
-  422: GET_UsersByUserId_Response_422
-}
+export type GET_UsersByUserId_Response = GET_UsersByUserId_Response_200 | GET_UsersByUserId_Response_422;
 
 /**
  * 200 response for GET UsersByUserId endpoint
@@ -5114,7 +4857,7 @@ export type GET_UsersByUserId = {
  *
  * @path /v1/users/{user_id}
  *
- * @see {@link GET_UsersByUserId} - The main response type definition
+ * @see {@link GET_UsersByUserId_Response} - The main response type definition
  * @see {@link UserWithAttributes} - The actual schema type definition
  */
 export type GET_UsersByUserId_Response_200 = UserWithAttributes
@@ -5131,7 +4874,7 @@ export type GET_UsersByUserId_Response_200 = UserWithAttributes
  *
  * @path /v1/users/{user_id}
  *
- * @see {@link GET_UsersByUserId} - The main response type definition
+ * @see {@link GET_UsersByUserId_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type GET_UsersByUserId_Response_422 = HTTPValidationError
@@ -5155,10 +4898,7 @@ export type GET_UsersByUserId_Response_422 = HTTPValidationError
  *
 
  */
-export type PATCH_UsersByUserId = {
-  200: PATCH_UsersByUserId_Response_200
-  422: PATCH_UsersByUserId_Response_422
-}
+export type PATCH_UsersByUserId_Response = PATCH_UsersByUserId_Response_200 | PATCH_UsersByUserId_Response_422;
 
 /**
  * 200 response for PATCH UsersByUserId endpoint
@@ -5172,7 +4912,7 @@ export type PATCH_UsersByUserId = {
  *
  * @path /v1/users/{user_id}
  *
- * @see {@link PATCH_UsersByUserId} - The main response type definition
+ * @see {@link PATCH_UsersByUserId_Response} - The main response type definition
  * @see {@link UserWithAttributes} - The actual schema type definition
  */
 export type PATCH_UsersByUserId_Response_200 = UserWithAttributes
@@ -5189,7 +4929,7 @@ export type PATCH_UsersByUserId_Response_200 = UserWithAttributes
  *
  * @path /v1/users/{user_id}
  *
- * @see {@link PATCH_UsersByUserId} - The main response type definition
+ * @see {@link PATCH_UsersByUserId_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type PATCH_UsersByUserId_Response_422 = HTTPValidationError
@@ -5213,10 +4953,7 @@ export type PATCH_UsersByUserId_Response_422 = HTTPValidationError
  *
 
  */
-export type GET_UsersByUserIdPermissions = {
-  200: GET_UsersByUserIdPermissions_Response_200
-  422: GET_UsersByUserIdPermissions_Response_422
-}
+export type GET_UsersByUserIdPermissions_Response = GET_UsersByUserIdPermissions_Response_200 | GET_UsersByUserIdPermissions_Response_422;
 
 /**
  * 200 response for GET UsersByUserIdPermissions endpoint
@@ -5230,7 +4967,7 @@ export type GET_UsersByUserIdPermissions = {
  *
  * @path /v1/users/{user_id}/permissions
  *
- * @see {@link GET_UsersByUserIdPermissions} - The main response type definition
+ * @see {@link GET_UsersByUserIdPermissions_Response} - The main response type definition
  * @see {@link PermissionSet} - The actual schema type definition
  */
 export type GET_UsersByUserIdPermissions_Response_200 = PermissionSet
@@ -5247,7 +4984,7 @@ export type GET_UsersByUserIdPermissions_Response_200 = PermissionSet
  *
  * @path /v1/users/{user_id}/permissions
  *
- * @see {@link GET_UsersByUserIdPermissions} - The main response type definition
+ * @see {@link GET_UsersByUserIdPermissions_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type GET_UsersByUserIdPermissions_Response_422 = HTTPValidationError
@@ -5271,10 +5008,7 @@ export type GET_UsersByUserIdPermissions_Response_422 = HTTPValidationError
  *
 
  */
-export type GET_UsersByUserIdRoles = {
-  200: GET_UsersByUserIdRoles_Response_200
-  422: GET_UsersByUserIdRoles_Response_422
-}
+export type GET_UsersByUserIdRoles_Response = GET_UsersByUserIdRoles_Response_200 | GET_UsersByUserIdRoles_Response_422;
 
 /**
  * 200 response for GET UsersByUserIdRoles endpoint
@@ -5288,7 +5022,7 @@ export type GET_UsersByUserIdRoles = {
  *
  * @path /v1/users/{user_id}/roles
  *
- * @see {@link GET_UsersByUserIdRoles} - The main response type definition
+ * @see {@link GET_UsersByUserIdRoles_Response} - The main response type definition
  * @see {@link RelationSet} - The actual schema type definition
  */
 export type GET_UsersByUserIdRoles_Response_200 = RelationSet
@@ -5305,7 +5039,7 @@ export type GET_UsersByUserIdRoles_Response_200 = RelationSet
  *
  * @path /v1/users/{user_id}/roles
  *
- * @see {@link GET_UsersByUserIdRoles} - The main response type definition
+ * @see {@link GET_UsersByUserIdRoles_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type GET_UsersByUserIdRoles_Response_422 = HTTPValidationError
@@ -5329,10 +5063,7 @@ export type GET_UsersByUserIdRoles_Response_422 = HTTPValidationError
  *
 
  */
-export type PATCH_UsersByUserIdRoles = {
-  200: PATCH_UsersByUserIdRoles_Response_200
-  422: PATCH_UsersByUserIdRoles_Response_422
-}
+export type PATCH_UsersByUserIdRoles_Response = PATCH_UsersByUserIdRoles_Response_200 | PATCH_UsersByUserIdRoles_Response_422;
 
 /**
  * 200 response for PATCH UsersByUserIdRoles endpoint
@@ -5346,7 +5077,7 @@ export type PATCH_UsersByUserIdRoles = {
  *
  * @path /v1/users/{user_id}/roles
  *
- * @see {@link PATCH_UsersByUserIdRoles} - The main response type definition
+ * @see {@link PATCH_UsersByUserIdRoles_Response} - The main response type definition
  * @see {@link RelationSet} - The actual schema type definition
  */
 export type PATCH_UsersByUserIdRoles_Response_200 = RelationSet
@@ -5363,7 +5094,7 @@ export type PATCH_UsersByUserIdRoles_Response_200 = RelationSet
  *
  * @path /v1/users/{user_id}/roles
  *
- * @see {@link PATCH_UsersByUserIdRoles} - The main response type definition
+ * @see {@link PATCH_UsersByUserIdRoles_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type PATCH_UsersByUserIdRoles_Response_422 = HTTPValidationError
@@ -5387,10 +5118,7 @@ export type PATCH_UsersByUserIdRoles_Response_422 = HTTPValidationError
  *
 
  */
-export type GET_UsersMe = {
-  200: GET_UsersMe_Response_200
-  422: GET_UsersMe_Response_422
-}
+export type GET_UsersMe_Response = GET_UsersMe_Response_200 | GET_UsersMe_Response_422;
 
 /**
  * 200 response for GET UsersMe endpoint
@@ -5404,7 +5132,7 @@ export type GET_UsersMe = {
  *
  * @path /v1/users/me
  *
- * @see {@link GET_UsersMe} - The main response type definition
+ * @see {@link GET_UsersMe_Response} - The main response type definition
  * @see {@link UserWithRelationPermissions} - The actual schema type definition
  */
 export type GET_UsersMe_Response_200 = UserWithRelationPermissions
@@ -5421,7 +5149,7 @@ export type GET_UsersMe_Response_200 = UserWithRelationPermissions
  *
  * @path /v1/users/me
  *
- * @see {@link GET_UsersMe} - The main response type definition
+ * @see {@link GET_UsersMe_Response} - The main response type definition
  * @see {@link HTTPValidationError} - The actual schema type definition
  */
 export type GET_UsersMe_Response_422 = HTTPValidationError


### PR DESCRIPTION
I discovered a couple of bugs and issues when using the new paths.
And also inconsistencies with naming.

- responses and request naming is consistent.
- responses are now unions
- fixed a bug with a empty response that was output as name = ;
- fixed to unused imports