### PR TITLE
Use "unboxed" version of TypeID

### DIFF
--- a/scripts/generate-schema.ts
+++ b/scripts/generate-schema.ts
@@ -33,7 +33,7 @@ const ast = await openapiTS(schemaPath, {
 				}
 
 				const typeIdType = ts.factory.createTypeReferenceNode(
-					ts.factory.createIdentifier("TypeID"),
+					ts.factory.createIdentifier("TypeId"),
 					[
 						ts.factory.createLiteralTypeNode(
 							ts.factory.createStringLiteral(typeIdPrefix)
@@ -46,7 +46,7 @@ const ast = await openapiTS(schemaPath, {
 				return undefined;
 		}
 	},
-	inject: "import { TypeID } from 'typeid-js';",
+	inject: "import { TypeId } from 'typeid-js';",
 });
 const contents = astToString(ast);
 


### PR DESCRIPTION
https://github.com/jetify-com/opensource/tree/main/typeid/typeid-js/src/unboxed

We've been using TypeID wrong the whole time. The default one is class-based. Which is usually what you want. *Except* in serializing/deserializing context, like we have here. Because we're dealing with strings, we can say the type of `user_id` is `TypeID<'user'>`, but... that does not mean anything. Underneath, `typeof user_id` will be `string`, not `TypeID<'user'>`.

To fix this, we need to switch to "unboxed" version of TypeID, which _extends_ the `string` type. It gives us the same type security (and uses the boxed version of TypeID underneath), while playing very nicely with strings from JSON, etc.

Very confusingly, the switch means going from using `TypeID` to... `TypeId` 🤦 

### Testing
See https://github.com/OpusDNS/api-spec/pull/13 for nice instructions on how to use this version in a different project.

Run `npm run generate:schema` to verify that the correct types are generated into `src/schema.d.ts`. I'm not committing the generated schema so that the GitHub action workflow will kick in and publish a new version of the package 🤞 