### PR TITLE
docs: add Contact Verification guide under Products

### DIFF
--- a/scalar/content/contacts/attestation-workflow.md
+++ b/scalar/content/contacts/attestation-workflow.md
@@ -1,32 +1,15 @@
-# Contact verification
+# Attestation workflow
 
-Certain registries require domain holders to verify their identity. When a
-registry flags one of your contacts for verification, OpusDNS detects the
-requirement, notifies you, and provides API endpoints to submit the required
-attestations before the registry-imposed deadlines.
+When a registry flags one of your contacts for verification, follow this
+workflow to identify the affected domains, review the required claims, and
+submit attestations through the API.
 
-This guide explains how contact verification works, how to check which domains
-are affected, and how to resolve verification requirements through the API.
-
-## How verification works
-
-1. A registry (e.g., DENIC for `.de` domains) determines that a contact's
-   identity needs to be verified.
-2. OpusDNS receives the verification requirement and flags all affected domains.
-3. You receive an email notification and a
-   [`VERIFICATION`](/automation/events/event-object) event with details about the
-   affected contacts and domains.
-4. You submit attestations via the API to prove the contact's identity claims.
-5. Once all claims are verified, the registry clears the deadlines and OpusDNS
-   removes the verification flags automatically.
-
-<scalar-callout type="warning">
-Verification deadlines are enforced by the registry. If you do not complete verification in time, your domain may be de-delegated (DNS stops resolving) or ultimately deleted. Always act promptly when you receive a verification notification.
-</scalar-callout>
+For background on verification concepts (claims, methods, proofs, deadlines),
+see the [Contact verification overview](/products/contacts/verification).
 
 ## Flow overview
 
-1. Identify domains requiring verification.
+1. Identify domains and contacts requiring verification.
 2. Check which claims need to be attested for the affected contact.
 3. Submit attestations with the appropriate method, proof, and reference.
 4. Confirm the attestation result and track status tag removal.
@@ -177,15 +160,6 @@ curl "$OPUSDNS_API_BASE/v1/contacts/$CONTACT_ID/verifications" \
 }
 ```
 
-### Verification states
-
-| State | Meaning |
-| --- | --- |
-| `UNVERIFIED` | Claim has not been verified. Attestation is required. |
-| `IN_PROGRESS` | Attestation submitted, awaiting confirmation from the registry. |
-| `VERIFIED` | Claim successfully verified. No action needed. |
-| `EXPIRED` | Previous verification has expired. Re-attestation is required. |
-
 ### Error responses
 
 | Status | Meaning |
@@ -225,9 +199,9 @@ curl "$OPUSDNS_API_BASE/v1/contacts/$CONTACT_ID/verifications/attest" \
 | Field | Required | Description |
 | --- | --- | --- |
 | `attestations` | Yes | Array of attestation objects (max 50 per request). |
-| `attestations[].claim` | Yes | The claim being verified. See [Claims](#claims). |
-| `attestations[].method` | Yes | How the claim is being verified. See [Methods](#verification-methods). |
-| `attestations[].proof` | Yes | The specific evidence type used. See [Proofs](#verification-proofs). |
+| `attestations[].claim` | Yes | The claim being verified. See [Claims](/products/contacts/verification#claims). |
+| `attestations[].method` | Yes | How the claim is being verified. See [Methods](/products/contacts/verification#verification-methods). |
+| `attestations[].proof` | Yes | The specific evidence type used. See [Proofs](/products/contacts/verification#verification-proofs). |
 | `attestations[].attestation_reference` | Yes | Your reference identifier for the attestation (max 255 characters). |
 
 ### Response
@@ -277,106 +251,6 @@ curl --get "$OPUSDNS_API_BASE/v1/events" \
   --data-urlencode "type=VERIFICATION"
 ```
 
-## Claims
-
-Claims represent what the registry needs verified about a contact:
-
-| Claim | Description |
-| --- | --- |
-| `NAME` | The contact's first and last name. |
-| `ADDRESS` | The contact's postal address. |
-| `EMAIL` | The contact's email address. |
-| `PHONE` | The contact's phone number. |
-| `LEGAL_ENTITY` | The organization or company name. |
-
-## Verification methods
-
-How the identity claim is proven:
-
-| Method | Description |
-| --- | --- |
-| `AUTH` | Authentication-based verification. |
-| `VDIG` | Video identification (online ID check). |
-| `ELECTRONIC_DOCUMENT` | Electronic or digital document verification. |
-| `PHYSICAL_DOCUMENT` | Physical document verification (scanned or photographed). |
-| `BVR` | Postal verification via registered letter. |
-| `PVR` | Postal verification via standard mail. |
-| `DATA` | Data-based verification (cross-referencing authoritative databases). |
-| `REACHABILITY` | Reachability check (e.g., confirming email or phone access). |
-
-## Verification proofs
-
-The specific type of evidence used:
-
-| Proof | Description |
-| --- | --- |
-| `IDCARD` | National identity card. |
-| `PASSPORT` | Passport. |
-| `POPULATION_REGISTER` | Population or civil register extract. |
-| `RESIDENCE_PERMIT` | Residence permit. |
-| `PROOF_OF_ARRIVAL` | Proof of arrival / registration confirmation. |
-| `DRIVERS_LICENCE` | Driver's licence. |
-| `COMPANY_REGISTER` | Commercial register extract. |
-| `COMPANY_STATEMENT` | Company statement or declaration. |
-| `BANK_ACCOUNT` | Bank account verification. |
-| `ONLINE_PAYMENT_ACCOUNT` | Online payment account verification. |
-| `UTILITY_ACCOUNT` | Utility provider account. |
-| `BANK_STATEMENT` | Bank statement. |
-| `TAX_STATEMENT` | Tax statement. |
-| `WRITTEN_ATTESTATION` | Written attestation or declaration. |
-| `DIGITAL_ATTESTATION` | Digital attestation. |
-| `POSTAL_VER_TRANSACTION_LOG` | Postal verification transaction log. |
-| `EMAIL_VER_TRANSACTION_LOG` | Email verification transaction log. |
-| `ADDRESS_DATABASE` | Address database verification. |
-
-## Common attestation examples
-
-| Use case | Method | Proof |
-| --- | --- | --- |
-| Verify name with a passport | `PHYSICAL_DOCUMENT` | `PASSPORT` |
-| Verify name with an ID card | `PHYSICAL_DOCUMENT` | `IDCARD` |
-| Verify address with a utility bill | `DATA` | `UTILITY_ACCOUNT` |
-| Verify email via confirmation link | `REACHABILITY` | `EMAIL_VER_TRANSACTION_LOG` |
-| Verify company via commercial register | `DATA` | `COMPANY_REGISTER` |
-| Verify identity via video call | `VDIG` | `IDCARD` or `PASSPORT` |
-
-## Deadlines
-
-Verification deadlines are set by the registry. Missing them has real
-consequences for your domains:
-
-| Deadline type | What happens |
-| --- | --- |
-| `dedelegation` | The domain's DNS delegation is removed — it stops resolving. This is reversible once verification is completed. |
-| `deletion` | The domain is permanently deleted from the registry. This cannot be undone. |
-
-Deadlines follow a predictable sequence:
-
-1. **Notification** — you are informed that verification is required.
-2. **De-delegation** — if not resolved, DNS is removed and the domain goes
-   offline.
-3. **Deletion** — the domain is permanently removed from the registry.
-
-<scalar-callout type="warning">
-Always complete verification well before the de-delegation deadline to avoid any service interruption. Once a domain is deleted by the registry, it cannot be recovered through OpusDNS.
-</scalar-callout>
-
-## Notifications
-
-When verification is required, OpusDNS sends an email notification to your
-organization with details about the affected contacts and domains.
-
-You can configure where these notifications are sent in your organization
-settings:
-
-| Setting | Description |
-| --- | --- |
-| **Verification notification email** | A specific email address to receive verification notifications. |
-| **Enable/disable notifications** | Toggle verification email notifications on or off. |
-
-If no specific email is configured, notifications are sent to your
-organization's admin users.
-
 ## Troubleshooting
 
 | Issue | Cause | Resolution |
@@ -389,15 +263,7 @@ organization's admin users.
 
 ## Next steps
 
-- [Manage a domain](/products/domains/manage) — update domain settings
-- [Events overview](/products/events/overview) — monitor verification events
-- [Tags](/products/tags/overview) — filter domains and contacts by status tags
-
-## Related API reference
-
-- [`GET /v1/contacts/{contact_id}/verifications`](/api-reference#tag/contact/GET/v1/contacts/{contact_id}/verifications)
-- [`POST /v1/contacts/{contact_id}/verifications/attest`](/api-reference#tag/contact/POST/v1/contacts/{contact_id}/verifications/attest)
-- [`GET /v1/contacts`](/api-reference#tag/contact/GET/v1/contacts)
-- [`GET /v1/domains/{domain_reference}`](/api-reference#tag/domain/GET/v1/domains/{domain_reference})
-- [`GET /v1/domains`](/api-reference#tag/domain/GET/v1/domains)
-- [`GET /v1/events`](/api-reference#tag/event/GET/v1/events)
+- [Contact verification overview](/products/contacts/verification) — claims,
+  methods, proofs, and deadline reference
+- [Initialize verification](/products/contacts/initialize-verification) —
+  proactively register contacts for verification

--- a/scalar/content/contacts/attestation-workflow.md
+++ b/scalar/content/contacts/attestation-workflow.md
@@ -230,8 +230,9 @@ directly in the response. You can immediately see whether each claim moved to
 Once all claims reach the `VERIFIED` state, the registry clears the deadlines.
 OpusDNS automatically:
 
-- Removes the `VERIFICATION_REQUIRED` status tag from the **contact** immediately after successful attestation.
-- Removes the `VERIFICATION_REQUIRED` status tag from affected **domains** on the next domain sync.
+- Removes the `VERIFICATION_REQUIRED` status tag from: 
+    - the **contact**: immediately after successful attestation
+    - affected **domains**: on the next domain sync.
 - Sets `verification_required` to `null` on affected domain responses.
 
 If any claims are still `IN_PROGRESS` after attestation (awaiting registry

--- a/scalar/content/contacts/attestation-workflow.md
+++ b/scalar/content/contacts/attestation-workflow.md
@@ -204,20 +204,31 @@ curl "$OPUSDNS_API_BASE/v1/contacts/$CONTACT_ID/verifications/attest" \
 | `attestations[].proof` | Yes | The specific evidence type used. See [Proofs](/products/contacts/verification#verification-proofs). |
 | `attestations[].attestation_reference` | Yes | Your reference identifier for the attestation (max 255 characters). |
 
+### Registry-specific constraints
+
+Some registries impose extra rules on top of the request format above. These
+constraints apply only when the contact is a registrant on domains of that TLD
+that currently require verification — for every other TLD, the standard request
+format applies.
+
+| TLD | Registry | Constraint |
+| --- | --- | --- |
+| `.de` | DENIC | All attestations in a single request must share the same `method`, `proof`, and `attestation_reference`. Submit one request per method/proof combination if the claims need different ones. |
+
+<scalar-callout type="warning">
+Violating a registry-specific constraint rejects the <strong>entire</strong> request — no attestation in it is submitted. Check the table above before batching attestations for a contact.
+</scalar-callout>
+
 ### Response
 
 The response returns the updated verification state for all claims — same
 format as the GET endpoint.
 
-<scalar-callout type="info">
-<strong>.de domain constraint:</strong> When the contact is a registrant on <code>.de</code> domains that currently require verification, all attestations in a single request <strong>must</strong> share the same <code>method</code>, <code>proof</code>, and <code>attestation_reference</code>. This is a DENIC registry limitation — submit separate requests if you need different methods or proofs for different claims.
-</scalar-callout>
-
 ### Error responses
 
 | Status | Code | Meaning |
 | --- | --- | --- |
-| `400` | `ERROR_DOMAIN_VERIFICATION_INCONSISTENT_METHOD_PROOF` | Attestations in the request use different methods or proofs (not allowed for `.de`). |
+| `400` | `ERROR_DOMAIN_VERIFICATION_INCONSISTENT_METHOD_PROOF` | Multiple attestations in one request use different methods or proofs, which the registry does not allow. See [Registry-specific constraints](#registry-specific-constraints). |
 | `404` | `ERROR_CONTACT_VERIFICATION_UPSTREAM_NOT_FOUND` | Contact has not been registered for verification. |
 | `502` | `ERROR_CONTACT_VERIFICATION_UPSTREAM_ERROR` | Verification service temporarily unavailable. |
 
@@ -261,7 +272,7 @@ By default, the events API returns only pending (unacknowledged) events. Pass <c
 | Issue | Cause | Resolution |
 | --- | --- | --- |
 | `404` on GET verification status | Contact hasn't been flagged for verification yet. | Wait for the verification process to initialize, or check that you're using the correct contact ID. |
-| `400` inconsistent method/proof | Multiple attestations use different methods or proofs in one request (`.de` restriction). | Submit separate requests — one per method/proof combination. |
+| `400` inconsistent method/proof | Multiple attestations use different methods or proofs in one request (`.de` restriction). | Submit separate requests — one per method/proof combination. See [Registry-specific constraints](#registry-specific-constraints). |
 | Claims stuck in `IN_PROGRESS` | Registry hasn't confirmed the attestation yet. | Wait and poll again. Registry confirmation can take time. |
 | Contact tag removed but domain tag remains | Contact tag is removed immediately after attestation; domain tags are cleared on the next sync cycle. | Wait a few minutes for the domain sync to run. |
 | `verification_required` still present after `VERIFIED` | Domain hasn't synced yet. | The field is cleared on the next domain sync cycle. This typically happens within minutes. |

--- a/scalar/content/contacts/attestation-workflow.md
+++ b/scalar/content/contacts/attestation-workflow.md
@@ -251,6 +251,10 @@ curl --get "$OPUSDNS_API_BASE/v1/events" \
   --data-urlencode "type=VERIFICATION"
 ```
 
+<scalar-callout type="info">
+By default, the events API returns only pending (unacknowledged) events. Pass <code>acknowledged=true</code> to list events you have already acknowledged.
+</scalar-callout>
+
 ## Troubleshooting
 
 | Issue | Cause | Resolution |

--- a/scalar/content/contacts/contact-verification.md
+++ b/scalar/content/contacts/contact-verification.md
@@ -28,7 +28,7 @@ Verification deadlines are enforced by the registry. If you do not complete veri
 1. Identify domains requiring verification.
 2. Check which claims need to be attested for the affected contact.
 3. Submit attestations with the appropriate method, proof, and reference.
-4. Monitor until all claims reach `VERIFIED` state.
+4. Confirm the attestation result and track status tag removal.
 
 ## 1. Identify affected domains and contacts
 
@@ -246,14 +246,11 @@ format as the GET endpoint.
 | `404` | `ERROR_CONTACT_VERIFICATION_UPSTREAM_NOT_FOUND` | Contact has not been registered for verification. |
 | `502` | `ERROR_CONTACT_VERIFICATION_UPSTREAM_ERROR` | Verification service temporarily unavailable. |
 
-## 4. Monitor progress
+## 4. After attestation
 
-After submitting attestations, poll the verification status to track progress:
-
-```bash
-curl "$OPUSDNS_API_BASE/v1/contacts/$CONTACT_ID/verifications" \
-  --header "X-Api-Key: $OPUSDNS_API_KEY"
-```
+The attest endpoint returns the updated verification state for all claims
+directly in the response. You can immediately see whether each claim moved to
+`VERIFIED` or `IN_PROGRESS`.
 
 Once all claims reach the `VERIFIED` state, the registry clears the deadlines.
 OpusDNS automatically:
@@ -261,6 +258,14 @@ OpusDNS automatically:
 - Removes the `VERIFICATION_REQUIRED` status tag from the **contact** immediately after successful attestation.
 - Removes the `VERIFICATION_REQUIRED` status tag from affected **domains** on the next domain sync.
 - Sets `verification_required` to `null` on affected domain responses.
+
+If any claims are still `IN_PROGRESS` after attestation (awaiting registry
+confirmation), you can check back later using the GET endpoint:
+
+```bash
+curl "$OPUSDNS_API_BASE/v1/contacts/$CONTACT_ID/verifications" \
+  --header "X-Api-Key: $OPUSDNS_API_KEY"
+```
 
 You can also monitor verification-related events through the events API:
 

--- a/scalar/content/contacts/contact-verification.md
+++ b/scalar/content/contacts/contact-verification.md
@@ -14,7 +14,7 @@ are affected, and how to resolve verification requirements through the API.
    identity needs to be verified.
 2. OpusDNS receives the verification requirement and flags all affected domains.
 3. You receive an email notification and a
-   [`VERIFICATION`](/products/events/overview) event with details about the
+   [`VERIFICATION`](/automation/events/event-object) event with details about the
    affected contacts and domains.
 4. You submit attestations via the API to prove the contact's identity claims.
 5. Once all claims are verified, the registry clears the deadlines and OpusDNS

--- a/scalar/content/contacts/contact-verification.md
+++ b/scalar/content/contacts/contact-verification.md
@@ -13,8 +13,9 @@ are affected, and how to resolve verification requirements through the API.
 1. A registry (e.g., DENIC for `.de` domains) determines that a contact's
    identity needs to be verified.
 2. OpusDNS receives the verification requirement and flags all affected domains.
-3. You receive an email notification with details about the affected contacts
-   and domains.
+3. You receive an email notification and a
+   [`VERIFICATION`](/products/events/overview) event with details about the
+   affected contacts and domains.
 4. You submit attestations via the API to prove the contact's identity claims.
 5. Once all claims are verified, the registry clears the deadlines and OpusDNS
    removes the verification flags automatically.

--- a/scalar/content/contacts/contact-verification.md
+++ b/scalar/content/contacts/contact-verification.md
@@ -1,0 +1,397 @@
+# Contact verification
+
+Certain registries require domain holders to verify their identity. When a
+registry flags one of your contacts for verification, OpusDNS detects the
+requirement, notifies you, and provides API endpoints to submit the required
+attestations before the registry-imposed deadlines.
+
+This guide explains how contact verification works, how to check which domains
+are affected, and how to resolve verification requirements through the API.
+
+## How verification works
+
+1. A registry (e.g., DENIC for `.de` domains) determines that a contact's
+   identity needs to be verified.
+2. OpusDNS receives the verification requirement and flags all affected domains.
+3. You receive an email notification with details about the affected contacts
+   and domains.
+4. You submit attestations via the API to prove the contact's identity claims.
+5. Once all claims are verified, the registry clears the deadlines and OpusDNS
+   removes the verification flags automatically.
+
+<scalar-callout type="warning">
+Verification deadlines are enforced by the registry. If you do not complete verification in time, your domain may be de-delegated (DNS stops resolving) or ultimately deleted. Always act promptly when you receive a verification notification.
+</scalar-callout>
+
+## Flow overview
+
+1. Identify domains requiring verification.
+2. Check which claims need to be attested for the affected contact.
+3. Submit attestations with the appropriate method, proof, and reference.
+4. Monitor until all claims reach `VERIFIED` state.
+
+## 1. Identify affected domains and contacts
+
+When verification is required, both the affected **domains** and **contacts**
+are tagged with `VERIFICATION_REQUIRED`. Domains also include a
+`verification_required` field in their response containing the specific claims
+and deadlines.
+
+### Filter domains by status tag
+
+List all domains currently requiring verification:
+
+```bash
+curl --get "$OPUSDNS_API_BASE/v1/domains" \
+  --header "X-Api-Key: $OPUSDNS_API_KEY" \
+  --data-urlencode "status_tags=VERIFICATION_REQUIRED"
+```
+
+### Filter contacts by status tag
+
+List all contacts currently requiring verification:
+
+```bash
+curl --get "$OPUSDNS_API_BASE/v1/contacts" \
+  --header "X-Api-Key: $OPUSDNS_API_KEY" \
+  --data-urlencode "status_tags=VERIFICATION_REQUIRED" \
+  --data-urlencode "include=tags"
+```
+
+The response includes a `status_tags` field on each contact when `include=tags`
+is specified:
+
+```json
+{
+  "contact_id": "contact_01jxe1nzrmf78scaqbkjx0va0f",
+  "first_name": "Jane",
+  "last_name": "Smith",
+  "status_tags": [
+    {
+      "label": "VERIFICATION REQUIRED",
+      "type": "VERIFICATION_REQUIRED"
+    }
+  ]
+}
+```
+
+<scalar-callout type="info">
+You can combine <code>status_tags</code> with <code>status_tag_mode</code> (<code>match_any</code> or <code>match_all</code>) to control how multiple status tag filters are combined.
+</scalar-callout>
+
+### Check the verification_required field on domains
+
+Every domain response includes a `verification_required` field. When
+verification is needed, it contains the pending claims and deadlines. When no
+verification is required, it is `null`.
+
+```bash
+curl "$OPUSDNS_API_BASE/v1/domains/example.de" \
+  --header "X-Api-Key: $OPUSDNS_API_KEY"
+```
+
+```json
+{
+  "domain_id": "domain_01jxe1nzrmf78scaqbkjx0va0f",
+  "name": "example.de",
+  "verification_required": {
+    "claims": ["email", "name", "address"],
+    "deadlines": [
+      {
+        "type": "dedelegation",
+        "date": "2026-07-15T00:00:00Z"
+      },
+      {
+        "type": "deletion",
+        "date": "2026-08-15T00:00:00Z"
+      }
+    ]
+  }
+}
+```
+
+When no verification is pending, the field is `null`:
+
+```json
+{
+  "domain_id": "domain_01jxe1nzrmf78scaqbkjx0va0f",
+  "name": "example.de",
+  "verification_required": null
+}
+```
+
+### Verification fields
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `verification_required` | `object \| null` | Present when verification is required, `null` otherwise. |
+| `verification_required.claims` | `string[]` | Identity claims that require verification. Values: `name`, `address`, `email`, `phone`. |
+| `verification_required.deadlines` | `object[]` | Registry-imposed deadlines with consequences if verification is not completed. |
+| `verification_required.deadlines[].type` | `string` | `dedelegation` — DNS stops resolving. `deletion` — domain is permanently removed. |
+| `verification_required.deadlines[].date` | `string` | ISO 8601 UTC timestamp of the deadline. |
+
+## 2. Check verification status
+
+Retrieve the current verification state for a contact. This returns the status
+of each individual claim:
+
+```bash
+curl "$OPUSDNS_API_BASE/v1/contacts/$CONTACT_ID/verifications" \
+  --header "X-Api-Key: $OPUSDNS_API_KEY"
+```
+
+### Response
+
+```json
+{
+  "verifications": [
+    {
+      "claim": "NAME",
+      "state": "VERIFIED",
+      "method": "PHYSICAL_DOCUMENT",
+      "proof": "PASSPORT",
+      "attestation_reference": "REF-2026-001",
+      "verified_on": "2026-05-10T14:30:00Z",
+      "expires_on": "2027-05-10T14:30:00Z"
+    },
+    {
+      "claim": "ADDRESS",
+      "state": "UNVERIFIED",
+      "method": null,
+      "proof": null,
+      "attestation_reference": null,
+      "verified_on": null,
+      "expires_on": null
+    },
+    {
+      "claim": "EMAIL",
+      "state": "IN_PROGRESS",
+      "method": "REACHABILITY",
+      "proof": "EMAIL_VER_TRANSACTION_LOG",
+      "attestation_reference": "email-verif-20260518",
+      "verified_on": null,
+      "expires_on": null
+    }
+  ]
+}
+```
+
+### Verification states
+
+| State | Meaning |
+| --- | --- |
+| `UNVERIFIED` | Claim has not been verified. Attestation is required. |
+| `IN_PROGRESS` | Attestation submitted, awaiting confirmation from the registry. |
+| `VERIFIED` | Claim successfully verified. No action needed. |
+| `EXPIRED` | Previous verification has expired. Re-attestation is required. |
+
+### Error responses
+
+| Status | Meaning |
+| --- | --- |
+| `404` | Contact has not yet been flagged for verification. This typically means verification has not been initiated for this contact. |
+| `502` | The verification service is temporarily unavailable. Retry later. |
+
+## 3. Submit attestations
+
+Submit one or more attestations to verify identity claims for a contact:
+
+```bash
+curl "$OPUSDNS_API_BASE/v1/contacts/$CONTACT_ID/verifications/attest" \
+  --request POST \
+  --header "X-Api-Key: $OPUSDNS_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "attestations": [
+      {
+        "claim": "NAME",
+        "method": "PHYSICAL_DOCUMENT",
+        "proof": "PASSPORT",
+        "attestation_reference": "REF-2026-001"
+      },
+      {
+        "claim": "ADDRESS",
+        "method": "PHYSICAL_DOCUMENT",
+        "proof": "PASSPORT",
+        "attestation_reference": "REF-2026-001"
+      }
+    ]
+  }'
+```
+
+### Request fields
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `attestations` | Yes | Array of attestation objects (max 50 per request). |
+| `attestations[].claim` | Yes | The claim being verified. See [Claims](#claims). |
+| `attestations[].method` | Yes | How the claim is being verified. See [Methods](#verification-methods). |
+| `attestations[].proof` | Yes | The specific evidence type used. See [Proofs](#verification-proofs). |
+| `attestations[].attestation_reference` | Yes | Your reference identifier for the attestation (max 255 characters). |
+
+### Response
+
+The response returns the updated verification state for all claims — same
+format as the GET endpoint.
+
+<scalar-callout type="info">
+<strong>.de domain constraint:</strong> When the contact is a registrant on <code>.de</code> domains that currently require verification, all attestations in a single request <strong>must</strong> share the same <code>method</code>, <code>proof</code>, and <code>attestation_reference</code>. This is a DENIC registry limitation — submit separate requests if you need different methods or proofs for different claims.
+</scalar-callout>
+
+### Error responses
+
+| Status | Code | Meaning |
+| --- | --- | --- |
+| `400` | `ERROR_DOMAIN_VERIFICATION_INCONSISTENT_METHOD_PROOF` | Attestations in the request use different methods or proofs (not allowed for `.de`). |
+| `404` | `ERROR_CONTACT_VERIFICATION_UPSTREAM_NOT_FOUND` | Contact has not been registered for verification. |
+| `502` | `ERROR_CONTACT_VERIFICATION_UPSTREAM_ERROR` | Verification service temporarily unavailable. |
+
+## 4. Monitor progress
+
+After submitting attestations, poll the verification status to track progress:
+
+```bash
+curl "$OPUSDNS_API_BASE/v1/contacts/$CONTACT_ID/verifications" \
+  --header "X-Api-Key: $OPUSDNS_API_KEY"
+```
+
+Once all claims reach the `VERIFIED` state, the registry clears the deadlines.
+OpusDNS automatically:
+
+- Removes the `VERIFICATION_REQUIRED` status tag from the **contact** immediately after successful attestation.
+- Removes the `VERIFICATION_REQUIRED` status tag from affected **domains** on the next domain sync.
+- Sets `verification_required` to `null` on affected domain responses.
+
+You can also monitor verification-related events through the events API:
+
+```bash
+curl --get "$OPUSDNS_API_BASE/v1/events" \
+  --header "X-Api-Key: $OPUSDNS_API_KEY" \
+  --data-urlencode "object_type=CONTACT" \
+  --data-urlencode "type=VERIFICATION"
+```
+
+## Claims
+
+Claims represent what the registry needs verified about a contact:
+
+| Claim | Description |
+| --- | --- |
+| `NAME` | The contact's first and last name. |
+| `ADDRESS` | The contact's postal address. |
+| `EMAIL` | The contact's email address. |
+| `PHONE` | The contact's phone number. |
+| `LEGAL_ENTITY` | The organization or company name. |
+
+## Verification methods
+
+How the identity claim is proven:
+
+| Method | Description |
+| --- | --- |
+| `AUTH` | Authentication-based verification. |
+| `VDIG` | Video identification (online ID check). |
+| `ELECTRONIC_DOCUMENT` | Electronic or digital document verification. |
+| `PHYSICAL_DOCUMENT` | Physical document verification (scanned or photographed). |
+| `BVR` | Postal verification via registered letter. |
+| `PVR` | Postal verification via standard mail. |
+| `DATA` | Data-based verification (cross-referencing authoritative databases). |
+| `REACHABILITY` | Reachability check (e.g., confirming email or phone access). |
+
+## Verification proofs
+
+The specific type of evidence used:
+
+| Proof | Description |
+| --- | --- |
+| `IDCARD` | National identity card. |
+| `PASSPORT` | Passport. |
+| `POPULATION_REGISTER` | Population or civil register extract. |
+| `RESIDENCE_PERMIT` | Residence permit. |
+| `PROOF_OF_ARRIVAL` | Proof of arrival / registration confirmation. |
+| `DRIVERS_LICENCE` | Driver's licence. |
+| `COMPANY_REGISTER` | Commercial register extract. |
+| `COMPANY_STATEMENT` | Company statement or declaration. |
+| `BANK_ACCOUNT` | Bank account verification. |
+| `ONLINE_PAYMENT_ACCOUNT` | Online payment account verification. |
+| `UTILITY_ACCOUNT` | Utility provider account. |
+| `BANK_STATEMENT` | Bank statement. |
+| `TAX_STATEMENT` | Tax statement. |
+| `WRITTEN_ATTESTATION` | Written attestation or declaration. |
+| `DIGITAL_ATTESTATION` | Digital attestation. |
+| `POSTAL_VER_TRANSACTION_LOG` | Postal verification transaction log. |
+| `EMAIL_VER_TRANSACTION_LOG` | Email verification transaction log. |
+| `ADDRESS_DATABASE` | Address database verification. |
+
+## Common attestation examples
+
+| Use case | Method | Proof |
+| --- | --- | --- |
+| Verify name with a passport | `PHYSICAL_DOCUMENT` | `PASSPORT` |
+| Verify name with an ID card | `PHYSICAL_DOCUMENT` | `IDCARD` |
+| Verify address with a utility bill | `DATA` | `UTILITY_ACCOUNT` |
+| Verify email via confirmation link | `REACHABILITY` | `EMAIL_VER_TRANSACTION_LOG` |
+| Verify company via commercial register | `DATA` | `COMPANY_REGISTER` |
+| Verify identity via video call | `VDIG` | `IDCARD` or `PASSPORT` |
+
+## Deadlines
+
+Verification deadlines are set by the registry. Missing them has real
+consequences for your domains:
+
+| Deadline type | What happens |
+| --- | --- |
+| `dedelegation` | The domain's DNS delegation is removed — it stops resolving. This is reversible once verification is completed. |
+| `deletion` | The domain is permanently deleted from the registry. This cannot be undone. |
+
+Deadlines follow a predictable sequence:
+
+1. **Notification** — you are informed that verification is required.
+2. **De-delegation** — if not resolved, DNS is removed and the domain goes
+   offline.
+3. **Deletion** — the domain is permanently removed from the registry.
+
+<scalar-callout type="warning">
+Always complete verification well before the de-delegation deadline to avoid any service interruption. Once a domain is deleted by the registry, it cannot be recovered through OpusDNS.
+</scalar-callout>
+
+## Notifications
+
+When verification is required, OpusDNS sends an email notification to your
+organization with details about the affected contacts and domains.
+
+You can configure where these notifications are sent in your organization
+settings:
+
+| Setting | Description |
+| --- | --- |
+| **Verification notification email** | A specific email address to receive verification notifications. |
+| **Enable/disable notifications** | Toggle verification email notifications on or off. |
+
+If no specific email is configured, notifications are sent to your
+organization's admin users.
+
+## Troubleshooting
+
+| Issue | Cause | Resolution |
+| --- | --- | --- |
+| `404` on GET verification status | Contact hasn't been flagged for verification yet. | Wait for the verification process to initialize, or check that you're using the correct contact ID. |
+| `400` inconsistent method/proof | Multiple attestations use different methods or proofs in one request (`.de` restriction). | Submit separate requests — one per method/proof combination. |
+| Claims stuck in `IN_PROGRESS` | Registry hasn't confirmed the attestation yet. | Wait and poll again. Registry confirmation can take time. |
+| Contact tag removed but domain tag remains | Contact tag is removed immediately after attestation; domain tags are cleared on the next sync cycle. | Wait a few minutes for the domain sync to run. |
+| `verification_required` still present after `VERIFIED` | Domain hasn't synced yet. | The field is cleared on the next domain sync cycle. This typically happens within minutes. |
+
+## Next steps
+
+- [Manage a domain](/products/domains/manage) — update domain settings
+- [Events overview](/products/events/overview) — monitor verification events
+- [Tags](/products/tags/overview) — filter domains and contacts by status tags
+
+## Related API reference
+
+- [`GET /v1/contacts/{contact_id}/verifications`](/api-reference#tag/contact/GET/v1/contacts/{contact_id}/verifications)
+- [`POST /v1/contacts/{contact_id}/verifications/attest`](/api-reference#tag/contact/POST/v1/contacts/{contact_id}/verifications/attest)
+- [`GET /v1/contacts`](/api-reference#tag/contact/GET/v1/contacts)
+- [`GET /v1/domains/{domain_reference}`](/api-reference#tag/domain/GET/v1/domains/{domain_reference})
+- [`GET /v1/domains`](/api-reference#tag/domain/GET/v1/domains)
+- [`GET /v1/events`](/api-reference#tag/event/GET/v1/events)

--- a/scalar/content/contacts/initialize-verification.md
+++ b/scalar/content/contacts/initialize-verification.md
@@ -1,7 +1,7 @@
 # Initialize verification
 
 <scalar-callout type="info">
-This feature is coming soon. The endpoints described below are under active development and will be available in a future release.
+This feature is coming soon and is under active development.
 </scalar-callout>
 
 In addition to responding to registry-initiated verification requests, OpusDNS
@@ -9,98 +9,35 @@ will allow you to **trigger verification processes directly** — initiating
 email confirmations, identity checks, and other verification flows for your
 contacts without waiting for a registry to require them.
 
-## Why trigger verification proactively?
+## Why verify proactively?
 
 When a registry like DENIC flags a contact for verification, you are working
-against a deadline. Proactive verification lets you:
+against a deadline. By triggering verification ahead of time, you can:
 
-- **Verify contacts ahead of time** — complete verification before a registry
-  imposes deadlines, so your domains are never at risk of de-delegation or
-  deletion.
-- **Stay compliant** — ensure all contacts meet NIS2 identity verification
-  requirements without waiting for registry enforcement.
-- **Automate verification flows** — trigger email reachability checks, identity
-  verification sessions, and other processes directly through the API instead of
-  managing them externally.
+- **Avoid deadline pressure** — contacts are already verified when the registry
+  eventually requires it, so your domains are never at risk.
+- **Stay NIS2 compliant** — meet identity verification requirements without
+  waiting for registry enforcement.
 
-## How it will work
+## Verification flows
 
-### Register a contact for verification
+OpusDNS will support triggering the following verification processes directly
+for your registrants:
 
-You will be able to register a contact in the verification system, which
-initializes verification records for all applicable claims (name, address,
-email, phone, and legal entity where relevant):
-
-```bash
-curl "$OPUSDNS_API_BASE/v1/contacts/$CONTACT_ID/verifications/initialize" \
-  --request POST \
-  --header "X-Api-Key: $OPUSDNS_API_KEY" \
-  --header "Content-Type: application/json"
-```
-
-Once registered, you can trigger verification processes or submit attestations
-for any of the contact's claims.
-
-### Trigger verification processes
-
-Instead of only submitting external attestations, you will be able to kick off
-verification flows that OpusDNS manages on your behalf:
-
-- **Email verification** — send a confirmation email to the contact's address.
-  Once the registrant confirms, the `EMAIL` claim transitions to `VERIFIED`
-  automatically.
-- **Identity verification** — initiate an identity check session (e.g., video
+- **Email verification** — sends a confirmation email to the contact. Once the
+  registrant confirms, the `EMAIL` claim is verified automatically.
+- **Identity verification** — initiates an identity check session (e.g., video
   identification or document upload) where the registrant verifies their name
   and address directly.
 
-These flows handle the verification end-to-end — you trigger them via the API,
-the registrant completes the required steps, and the claim states update
+These flows are managed end-to-end by OpusDNS — you trigger them, the
+registrant completes the required steps, and the claim states update
 automatically.
 
-### Combine with attestations
-
-You can use both approaches together:
-
-| Approach | Best for |
-| --- | --- |
-| **Trigger a verification process** | Claims you want OpusDNS to verify directly with the registrant (e.g., email reachability, identity check). |
-| **Submit an attestation** | Claims you have already verified externally (e.g., passport checked in person, address confirmed via utility bill). |
-
-For example, you might trigger an email verification flow for the `EMAIL` claim
-while submitting a `PHYSICAL_DOCUMENT` attestation for the `NAME` claim — both
-in the same verification lifecycle.
-
-### Verification expiry
-
-Verified claims have an expiration date (typically one year from verification).
-When a verification expires, the claim state changes to `EXPIRED` and
-re-verification is required. You can monitor expiry dates in the verification
-status response:
-
-```json
-{
-  "claim": "NAME",
-  "state": "VERIFIED",
-  "method": "PHYSICAL_DOCUMENT",
-  "proof": "PASSPORT",
-  "attestation_reference": "REF-2026-001",
-  "verified_on": "2026-05-10T14:30:00Z",
-  "expires_on": "2027-05-10T14:30:00Z"
-}
-```
-
-Plan ahead by tracking `expires_on` dates and re-triggering verification or
-re-submitting attestations before they lapse.
-
-## What's coming
-
-- **Initialize endpoint** — register any contact for verification proactively.
-- **Email verification flow** — trigger email reachability checks directly
-  through the API.
-- **Identity verification flow** — initiate identity check sessions for
-  registrants.
-- **Expiry notifications** — receive events and email notifications when
-  verifications are approaching expiry.
+You can also combine triggered flows with
+[external attestations](/products/contacts/attestation-workflow) — for example,
+trigger an email verification for the `EMAIL` claim while submitting a document
+attestation for the `NAME` claim.
 
 ## Next steps
 

--- a/scalar/content/contacts/initialize-verification.md
+++ b/scalar/content/contacts/initialize-verification.md
@@ -5,22 +5,23 @@ This feature is coming soon. The endpoints described below are under active deve
 </scalar-callout>
 
 In addition to responding to registry-initiated verification requests, OpusDNS
-will support **proactively registering contacts for verification** — allowing
-you to verify identity claims before a registry requires it and to manage the
-full verification lifecycle through the API.
+will allow you to **trigger verification processes directly** — initiating
+email confirmations, identity checks, and other verification flows for your
+contacts without waiting for a registry to require them.
 
-## Why initialize verification proactively?
+## Why trigger verification proactively?
 
 When a registry like DENIC flags a contact for verification, you are working
 against a deadline. Proactive verification lets you:
 
-- **Verify contacts ahead of time** — submit attestations before a registry
+- **Verify contacts ahead of time** — complete verification before a registry
   imposes deadlines, so your domains are never at risk of de-delegation or
   deletion.
 - **Stay compliant** — ensure all contacts meet NIS2 identity verification
   requirements without waiting for registry enforcement.
-- **Manage the lifecycle** — keep contact data in sync with the verification
-  system and re-attest when verifications expire.
+- **Automate verification flows** — trigger email reachability checks, identity
+  verification sessions, and other processes directly through the API instead of
+  managing them externally.
 
 ## How it will work
 
@@ -37,23 +38,43 @@ curl "$OPUSDNS_API_BASE/v1/contacts/$CONTACT_ID/verifications/initialize" \
   --header "Content-Type: application/json"
 ```
 
-Once registered, you can immediately submit attestations using the existing
-[attestation workflow](/products/contacts/attestation-workflow) — the same
-`attest` endpoint works for both registry-initiated and proactively initialized
-verifications.
+Once registered, you can trigger verification processes or submit attestations
+for any of the contact's claims.
 
-### Update contact data
+### Trigger verification processes
 
-If contact details change after registration (e.g., a new address or updated
-email), updating the contact through the API may invalidate existing
-verifications for the affected claims. Those claims will revert to `UNVERIFIED`
-and require re-attestation.
+Instead of only submitting external attestations, you will be able to kick off
+verification flows that OpusDNS manages on your behalf:
+
+- **Email verification** — send a confirmation email to the contact's address.
+  Once the registrant confirms, the `EMAIL` claim transitions to `VERIFIED`
+  automatically.
+- **Identity verification** — initiate an identity check session (e.g., video
+  identification or document upload) where the registrant verifies their name
+  and address directly.
+
+These flows handle the verification end-to-end — you trigger them via the API,
+the registrant completes the required steps, and the claim states update
+automatically.
+
+### Combine with attestations
+
+You can use both approaches together:
+
+| Approach | Best for |
+| --- | --- |
+| **Trigger a verification process** | Claims you want OpusDNS to verify directly with the registrant (e.g., email reachability, identity check). |
+| **Submit an attestation** | Claims you have already verified externally (e.g., passport checked in person, address confirmed via utility bill). |
+
+For example, you might trigger an email verification flow for the `EMAIL` claim
+while submitting a `PHYSICAL_DOCUMENT` attestation for the `NAME` claim — both
+in the same verification lifecycle.
 
 ### Verification expiry
 
-Verified claims have an expiration date (typically one year from attestation).
+Verified claims have an expiration date (typically one year from verification).
 When a verification expires, the claim state changes to `EXPIRED` and
-re-attestation is required. You can monitor expiry dates in the verification
+re-verification is required. You can monitor expiry dates in the verification
 status response:
 
 ```json
@@ -68,23 +89,16 @@ status response:
 }
 ```
 
-Plan ahead by tracking `expires_on` dates and re-submitting attestations before
-they lapse.
-
-### Pre-verification vs. post-verification
-
-| Scenario | What to do |
-| --- | --- |
-| **New contact, no registry requirement yet** | Initialize verification and submit attestations proactively. When the registry eventually requires verification, the contact is already verified. |
-| **Registry has flagged a contact** | Follow the [attestation workflow](/products/contacts/attestation-workflow) to respond before the deadline. |
-| **Verification expired** | Re-submit attestations using the same `attest` endpoint. The claim will transition from `EXPIRED` back to `VERIFIED`. |
-| **Contact data changed** | Update the contact. Any affected claims revert to `UNVERIFIED` — re-attest those claims. |
+Plan ahead by tracking `expires_on` dates and re-triggering verification or
+re-submitting attestations before they lapse.
 
 ## What's coming
 
 - **Initialize endpoint** — register any contact for verification proactively.
-- **Contact data sync** — update contact details in the verification system
-  when they change in OpusDNS.
+- **Email verification flow** — trigger email reachability checks directly
+  through the API.
+- **Identity verification flow** — initiate identity check sessions for
+  registrants.
 - **Expiry notifications** — receive events and email notifications when
   verifications are approaching expiry.
 

--- a/scalar/content/contacts/initialize-verification.md
+++ b/scalar/content/contacts/initialize-verification.md
@@ -1,0 +1,96 @@
+# Initialize verification
+
+<scalar-callout type="info">
+This feature is coming soon. The endpoints described below are under active development and will be available in a future release.
+</scalar-callout>
+
+In addition to responding to registry-initiated verification requests, OpusDNS
+will support **proactively registering contacts for verification** — allowing
+you to verify identity claims before a registry requires it and to manage the
+full verification lifecycle through the API.
+
+## Why initialize verification proactively?
+
+When a registry like DENIC flags a contact for verification, you are working
+against a deadline. Proactive verification lets you:
+
+- **Verify contacts ahead of time** — submit attestations before a registry
+  imposes deadlines, so your domains are never at risk of de-delegation or
+  deletion.
+- **Stay compliant** — ensure all contacts meet NIS2 identity verification
+  requirements without waiting for registry enforcement.
+- **Manage the lifecycle** — keep contact data in sync with the verification
+  system and re-attest when verifications expire.
+
+## How it will work
+
+### Register a contact for verification
+
+You will be able to register a contact in the verification system, which
+initializes verification records for all applicable claims (name, address,
+email, phone, and legal entity where relevant):
+
+```bash
+curl "$OPUSDNS_API_BASE/v1/contacts/$CONTACT_ID/verifications/initialize" \
+  --request POST \
+  --header "X-Api-Key: $OPUSDNS_API_KEY" \
+  --header "Content-Type: application/json"
+```
+
+Once registered, you can immediately submit attestations using the existing
+[attestation workflow](/products/contacts/attestation-workflow) — the same
+`attest` endpoint works for both registry-initiated and proactively initialized
+verifications.
+
+### Update contact data
+
+If contact details change after registration (e.g., a new address or updated
+email), updating the contact through the API may invalidate existing
+verifications for the affected claims. Those claims will revert to `UNVERIFIED`
+and require re-attestation.
+
+### Verification expiry
+
+Verified claims have an expiration date (typically one year from attestation).
+When a verification expires, the claim state changes to `EXPIRED` and
+re-attestation is required. You can monitor expiry dates in the verification
+status response:
+
+```json
+{
+  "claim": "NAME",
+  "state": "VERIFIED",
+  "method": "PHYSICAL_DOCUMENT",
+  "proof": "PASSPORT",
+  "attestation_reference": "REF-2026-001",
+  "verified_on": "2026-05-10T14:30:00Z",
+  "expires_on": "2027-05-10T14:30:00Z"
+}
+```
+
+Plan ahead by tracking `expires_on` dates and re-submitting attestations before
+they lapse.
+
+### Pre-verification vs. post-verification
+
+| Scenario | What to do |
+| --- | --- |
+| **New contact, no registry requirement yet** | Initialize verification and submit attestations proactively. When the registry eventually requires verification, the contact is already verified. |
+| **Registry has flagged a contact** | Follow the [attestation workflow](/products/contacts/attestation-workflow) to respond before the deadline. |
+| **Verification expired** | Re-submit attestations using the same `attest` endpoint. The claim will transition from `EXPIRED` back to `VERIFIED`. |
+| **Contact data changed** | Update the contact. Any affected claims revert to `UNVERIFIED` — re-attest those claims. |
+
+## What's coming
+
+- **Initialize endpoint** — register any contact for verification proactively.
+- **Contact data sync** — update contact details in the verification system
+  when they change in OpusDNS.
+- **Expiry notifications** — receive events and email notifications when
+  verifications are approaching expiry.
+
+## Next steps
+
+- [Contact verification overview](/products/contacts/verification) — claims,
+  methods, proofs, and deadline reference
+- [Attestation workflow](/products/contacts/attestation-workflow) — respond to
+  verification requests step by step

--- a/scalar/content/contacts/overview.md
+++ b/scalar/content/contacts/overview.md
@@ -1,0 +1,156 @@
+# Contact verification
+
+Certain registries require domain holders to verify their identity. When a
+registry flags one of your contacts for verification, OpusDNS detects the
+requirement, notifies you, and provides API endpoints to submit the required
+attestations before the registry-imposed deadlines.
+
+This guide explains what contact verification is, when it applies, and what
+the key concepts are. For step-by-step instructions, see the
+[Attestation workflow](/products/contacts/attestation-workflow).
+
+## How verification works
+
+1. A registry (e.g., DENIC for `.de` domains) determines that a contact's
+   identity needs to be verified.
+2. OpusDNS receives the verification requirement and flags all affected domains
+   and contacts.
+3. You receive an email notification and a
+   [`VERIFICATION`](/automation/events/event-object) event with details about the
+   affected contacts and domains.
+4. You submit attestations via the API to prove the contact's identity claims.
+5. Once all claims are verified, the registry clears the deadlines and OpusDNS
+   removes the verification flags automatically.
+
+<scalar-callout type="warning">
+Verification deadlines are enforced by the registry. If you do not complete verification in time, your domain may be de-delegated (DNS stops resolving) or ultimately deleted. Always act promptly when you receive a verification notification.
+</scalar-callout>
+
+## Claims
+
+Claims represent what the registry needs verified about a contact:
+
+| Claim | Description |
+| --- | --- |
+| `NAME` | The contact's first and last name. |
+| `ADDRESS` | The contact's postal address. |
+| `EMAIL` | The contact's email address. |
+| `PHONE` | The contact's phone number. |
+| `LEGAL_ENTITY` | The organization or company name. |
+
+## Verification methods
+
+How the identity claim is proven:
+
+| Method | Description |
+| --- | --- |
+| `AUTH` | Authentication-based verification. |
+| `VDIG` | Video identification (online ID check). |
+| `ELECTRONIC_DOCUMENT` | Electronic or digital document verification. |
+| `PHYSICAL_DOCUMENT` | Physical document verification (scanned or photographed). |
+| `BVR` | Postal verification via registered letter. |
+| `PVR` | Postal verification via standard mail. |
+| `DATA` | Data-based verification (cross-referencing authoritative databases). |
+| `REACHABILITY` | Reachability check (e.g., confirming email or phone access). |
+
+## Verification proofs
+
+The specific type of evidence used:
+
+| Proof | Description |
+| --- | --- |
+| `IDCARD` | National identity card. |
+| `PASSPORT` | Passport. |
+| `POPULATION_REGISTER` | Population or civil register extract. |
+| `RESIDENCE_PERMIT` | Residence permit. |
+| `PROOF_OF_ARRIVAL` | Proof of arrival / registration confirmation. |
+| `DRIVERS_LICENCE` | Driver's licence. |
+| `COMPANY_REGISTER` | Commercial register extract. |
+| `COMPANY_STATEMENT` | Company statement or declaration. |
+| `BANK_ACCOUNT` | Bank account verification. |
+| `ONLINE_PAYMENT_ACCOUNT` | Online payment account verification. |
+| `UTILITY_ACCOUNT` | Utility provider account. |
+| `BANK_STATEMENT` | Bank statement. |
+| `TAX_STATEMENT` | Tax statement. |
+| `WRITTEN_ATTESTATION` | Written attestation or declaration. |
+| `DIGITAL_ATTESTATION` | Digital attestation. |
+| `POSTAL_VER_TRANSACTION_LOG` | Postal verification transaction log. |
+| `EMAIL_VER_TRANSACTION_LOG` | Email verification transaction log. |
+| `ADDRESS_DATABASE` | Address database verification. |
+
+## Common attestation examples
+
+| Use case | Method | Proof |
+| --- | --- | --- |
+| Verify name with a passport | `PHYSICAL_DOCUMENT` | `PASSPORT` |
+| Verify name with an ID card | `PHYSICAL_DOCUMENT` | `IDCARD` |
+| Verify address with a utility bill | `DATA` | `UTILITY_ACCOUNT` |
+| Verify email via confirmation link | `REACHABILITY` | `EMAIL_VER_TRANSACTION_LOG` |
+| Verify company via commercial register | `DATA` | `COMPANY_REGISTER` |
+| Verify identity via video call | `VDIG` | `IDCARD` or `PASSPORT` |
+
+## Verification states
+
+Each claim on a contact has a verification state:
+
+| State | Meaning |
+| --- | --- |
+| `UNVERIFIED` | Claim has not been verified. Attestation is required. |
+| `IN_PROGRESS` | Attestation submitted, awaiting confirmation from the registry. |
+| `VERIFIED` | Claim successfully verified. No action needed. |
+| `EXPIRED` | Previous verification has expired. Re-attestation is required. |
+
+## Deadlines
+
+Verification deadlines are set by the registry. Missing them has real
+consequences for your domains:
+
+| Deadline type | What happens |
+| --- | --- |
+| `dedelegation` | The domain's DNS delegation is removed — it stops resolving. This is reversible once verification is completed. |
+| `deletion` | The domain is permanently deleted from the registry. This cannot be undone. |
+
+Deadlines follow a predictable sequence:
+
+1. **Notification** — you are informed that verification is required.
+2. **De-delegation** — if not resolved, DNS is removed and the domain goes
+   offline.
+3. **Deletion** — the domain is permanently removed from the registry.
+
+<scalar-callout type="warning">
+Always complete verification well before the de-delegation deadline to avoid any service interruption. Once a domain is deleted by the registry, it cannot be recovered through OpusDNS.
+</scalar-callout>
+
+## Notifications
+
+When verification is required, OpusDNS sends an email notification to your
+organization with details about the affected contacts and domains.
+
+You can configure where these notifications are sent in your organization
+settings:
+
+| Setting | Description |
+| --- | --- |
+| **Verification notification email** | A specific email address to receive verification notifications. |
+| **Enable/disable notifications** | Toggle verification email notifications on or off. |
+
+If no specific email is configured, notifications are sent to your
+organization's admin users.
+
+## Next steps
+
+- [Attestation workflow](/products/contacts/attestation-workflow) — respond to
+  registry-initiated verification requests step by step
+- [Initialize verification](/products/contacts/initialize-verification) —
+  proactively register and verify contacts before a registry requires it
+- [Events](/automation/events/event-object) — monitor verification events
+- [Tags](/products/tags/overview) — filter domains and contacts by status tags
+
+## Related API reference
+
+- [`GET /v1/contacts/{contact_id}/verifications`](/api-reference#tag/contact/GET/v1/contacts/{contact_id}/verifications)
+- [`POST /v1/contacts/{contact_id}/verifications/attest`](/api-reference#tag/contact/POST/v1/contacts/{contact_id}/verifications/attest)
+- [`GET /v1/contacts`](/api-reference#tag/contact/GET/v1/contacts)
+- [`GET /v1/domains/{domain_reference}`](/api-reference#tag/domain/GET/v1/domains/{domain_reference})
+- [`GET /v1/domains`](/api-reference#tag/domain/GET/v1/domains)
+- [`GET /v1/events`](/api-reference#tag/event/GET/v1/events)

--- a/scalar/scalar.config.json
+++ b/scalar/scalar.config.json
@@ -305,6 +305,20 @@
                   }
                 }
               },
+              "/contacts": {
+                "type": "group",
+                "title": "Contact Verification",
+                "icon": "phosphor/regular/shield-check",
+                "children": {
+                  "/verification": {
+                    "type": "page",
+                    "title": "Contact verification",
+                    "icon": "phosphor/regular/shield-check",
+                    "filepath": "content/contacts/contact-verification.md",
+                    "showInSidebar": true
+                  }
+                }
+              },
               "/tlds": {
                 "type": "group",
                 "title": "TLD Reference",

--- a/scalar/scalar.config.json
+++ b/scalar/scalar.config.json
@@ -312,9 +312,23 @@
                 "children": {
                   "/verification": {
                     "type": "page",
-                    "title": "Contact verification",
+                    "title": "Overview",
                     "icon": "phosphor/regular/shield-check",
-                    "filepath": "content/contacts/contact-verification.md",
+                    "filepath": "content/contacts/overview.md",
+                    "showInSidebar": true
+                  },
+                  "/attestation-workflow": {
+                    "type": "page",
+                    "title": "Attestation workflow",
+                    "icon": "line/interface-content-book-page",
+                    "filepath": "content/contacts/attestation-workflow.md",
+                    "showInSidebar": true
+                  },
+                  "/initialize-verification": {
+                    "type": "page",
+                    "title": "Initialize verification",
+                    "icon": "line/interface-add",
+                    "filepath": "content/contacts/initialize-verification.md",
                     "showInSidebar": true
                   }
                 }


### PR DESCRIPTION
Adds a new 'Contact Verification' section to the Products navigation with a comprehensive customer-facing guide covering:

- How verification requirements are triggered by registries
- Identifying affected domains and contacts via status tags
- The verification_required field on domain responses
- GET endpoint for checking verification status per claim
- POST endpoint for submitting attestations
- Full reference for claims, methods, and proofs
- Deadlines, consequences, and troubleshooting