### PR TITLE
feat(tld-kb): per-TLD notes files + .ca page

### DIFF
--- a/.github/workflows/tld-knowledge-base.yaml
+++ b/.github/workflows/tld-knowledge-base.yaml
@@ -12,6 +12,14 @@ on:
         default: main
   repository_dispatch:
     types: [tld_specifications_updated]
+  push:
+    branches: [main]
+    # Regenerate when the api-spec inputs to generation change (notes files or
+    # the generator itself). Spec changes are covered by repository_dispatch.
+    paths:
+      - 'scalar/content/tld-knowledge-base/_notes/**'
+      - 'scripts/tld_knowledge_base/**'
+      - 'scripts/generate_tld_knowledge_base.py'
   schedule:
     - cron: "0 5 * * 1"  # weekly safety net (Mondays 05:00 UTC)
 

--- a/scalar/content/tld-knowledge-base/_notes/_default.md
+++ b/scalar/content/tld-knowledge-base/_notes/_default.md
@@ -1,0 +1,6 @@
+## Implementation Notes
+
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/_notes/ca.md
+++ b/scalar/content/tld-knowledge-base/_notes/ca.md
@@ -1,0 +1,35 @@
+## Contact Attributes
+
+`.ca` registrations carry a registry-specific contact attribute beyond the standard EPP fields:
+
+| Attribute | Type | Required | Applies to | Allowed values |
+| --- | --- | --- | --- | --- |
+| `CIRA_CPR` | Enum | ✅ Required | Domain Owner | Any code in the table below |
+| `CIRA_CPR` | Enum | ❌ Optional | Administrator | `CCT`, `RES`, `LGR`, `ABO` |
+
+## Canadian Presence Requirement (CIRA_CPR)
+
+Every `.ca` domain must satisfy CIRA's [Canadian Presence Requirements](https://www.cira.ca/en/resources/documents/domains/canadian-presence-requirements-registrants/). The registrant declares which legal type establishes their Canadian presence through the `CIRA_CPR` attribute.
+
+| Code | Legal type |
+| --- | --- |
+| `ABO` | Aboriginal Peoples (individuals or groups) indigenous to Canada |
+| `ASS` | Canadian unincorporated association |
+| `CCO` | Canadian corporation, or Canadian province or territory |
+| `CCT` | Canadian citizen |
+| `EDU` | Canadian educational institution |
+| `GOV` | Government or government entity in Canada |
+| `HOP` | Canadian hospital |
+| `INB` | Indian Band recognized by the Indian Act of Canada |
+| `LAM` | Canadian library, archive, or museum |
+| `LGR` | Legal Representative of a Canadian Citizen or Permanent Resident |
+| `MAJ` | Her/His Majesty the Queen/King |
+| `OMK` | Official mark registered in Canada |
+| `PLT` | Canadian political party |
+| `PRT` | Partnership registered in Canada |
+| `RES` | Permanent resident of Canada |
+| `TDM` | Trade-mark registered in Canada (by a non-Canadian owner) |
+| `TRD` | Canadian trade union |
+| `TRS` | Trust established in Canada |
+
+Registrants whose legal type is `TDM` or `OMK` are exempt from the Canadian local-presence requirement: a Canadian-registered trade-mark or official mark satisfies the Canadian Presence Requirement on its own, so the registrant need not be located in Canada.

--- a/scalar/content/tld-knowledge-base/cctlds/ag.md
+++ b/scalar/content/tld-knowledge-base/cctlds/ag.md
@@ -106,8 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/ai.md
+++ b/scalar/content/tld-knowledge-base/cctlds/ai.md
@@ -106,8 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/at.md
+++ b/scalar/content/tld-knowledge-base/cctlds/at.md
@@ -105,8 +105,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 6 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/be.md
+++ b/scalar/content/tld-knowledge-base/cctlds/be.md
@@ -105,8 +105,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/bz.md
+++ b/scalar/content/tld-knowledge-base/cctlds/bz.md
@@ -106,8 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/ca.md
+++ b/scalar/content/tld-knowledge-base/cctlds/ca.md
@@ -113,10 +113,38 @@
 | Requirements | Physical Address, Business Entity |
 | Eligible Countries | CA |
 
-## Implementation Notes
+## Contact Attributes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 6 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+`.ca` registrations carry a registry-specific contact attribute beyond the standard EPP fields:
+
+| Attribute | Type | Required | Applies to | Allowed values |
+| --- | --- | --- | --- | --- |
+| `CIRA_CPR` | Enum | ✅ Required | Domain Owner | Any code in the table below |
+| `CIRA_CPR` | Enum | ❌ Optional | Administrator | `CCT`, `RES`, `LGR`, `ABO` |
+
+## Canadian Presence Requirement (CIRA_CPR)
+
+Every `.ca` domain must satisfy CIRA's [Canadian Presence Requirements](https://www.cira.ca/en/resources/documents/domains/canadian-presence-requirements-registrants/). The registrant declares which legal type establishes their Canadian presence through the `CIRA_CPR` attribute.
+
+| Code | Legal type |
+| --- | --- |
+| `ABO` | Aboriginal Peoples (individuals or groups) indigenous to Canada |
+| `ASS` | Canadian unincorporated association |
+| `CCO` | Canadian corporation, or Canadian province or territory |
+| `CCT` | Canadian citizen |
+| `EDU` | Canadian educational institution |
+| `GOV` | Government or government entity in Canada |
+| `HOP` | Canadian hospital |
+| `INB` | Indian Band recognized by the Indian Act of Canada |
+| `LAM` | Canadian library, archive, or museum |
+| `LGR` | Legal Representative of a Canadian Citizen or Permanent Resident |
+| `MAJ` | Her/His Majesty the Queen/King |
+| `OMK` | Official mark registered in Canada |
+| `PLT` | Canadian political party |
+| `PRT` | Partnership registered in Canada |
+| `RES` | Permanent resident of Canada |
+| `TDM` | Trade-mark registered in Canada (by a non-Canadian owner) |
+| `TRD` | Canadian trade union |
+| `TRS` | Trust established in Canada |
+
+Registrants whose legal type is `TDM` or `OMK` are exempt from the Canadian local-presence requirement: a Canadian-registered trade-mark or official mark satisfies the Canadian Presence Requirement on its own, so the registrant need not be located in Canada.

--- a/scalar/content/tld-knowledge-base/cctlds/cc.md
+++ b/scalar/content/tld-knowledge-base/cctlds/cc.md
@@ -106,8 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/ch.md
+++ b/scalar/content/tld-knowledge-base/cctlds/ch.md
@@ -106,8 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 6 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/co.md
+++ b/scalar/content/tld-knowledge-base/cctlds/co.md
@@ -106,8 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/com.de.md
+++ b/scalar/content/tld-knowledge-base/cctlds/com.de.md
@@ -106,8 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/com.se.md
+++ b/scalar/content/tld-knowledge-base/cctlds/com.se.md
@@ -106,8 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/cz.md
+++ b/scalar/content/tld-knowledge-base/cctlds/cz.md
@@ -102,8 +102,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/de.md
+++ b/scalar/content/tld-knowledge-base/cctlds/de.md
@@ -106,8 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/dk.md
+++ b/scalar/content/tld-knowledge-base/cctlds/dk.md
@@ -96,7 +96,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- AuthInfo must meet minimum requirements (≥ 6 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/eu.md
+++ b/scalar/content/tld-knowledge-base/cctlds/eu.md
@@ -105,8 +105,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/fr.md
+++ b/scalar/content/tld-knowledge-base/cctlds/fr.md
@@ -102,8 +102,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 12 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/io.md
+++ b/scalar/content/tld-knowledge-base/cctlds/io.md
@@ -106,8 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/it.md
+++ b/scalar/content/tld-knowledge-base/cctlds/it.md
@@ -102,8 +102,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 6 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/lc.md
+++ b/scalar/content/tld-knowledge-base/cctlds/lc.md
@@ -106,8 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/li.md
+++ b/scalar/content/tld-knowledge-base/cctlds/li.md
@@ -106,8 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 6 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/lt.md
+++ b/scalar/content/tld-knowledge-base/cctlds/lt.md
@@ -96,7 +96,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- AuthInfo must meet minimum requirements (≥ 6 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/lu.md
+++ b/scalar/content/tld-knowledge-base/cctlds/lu.md
@@ -101,8 +101,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 1 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/me.md
+++ b/scalar/content/tld-knowledge-base/cctlds/me.md
@@ -106,8 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/mn.md
+++ b/scalar/content/tld-knowledge-base/cctlds/mn.md
@@ -106,8 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/nl.md
+++ b/scalar/content/tld-knowledge-base/cctlds/nl.md
@@ -106,8 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 12 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/pl.md
+++ b/scalar/content/tld-knowledge-base/cctlds/pl.md
@@ -96,7 +96,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- AuthInfo must meet minimum requirements (≥ 6 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/pm.md
+++ b/scalar/content/tld-knowledge-base/cctlds/pm.md
@@ -102,8 +102,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 12 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/pr.md
+++ b/scalar/content/tld-knowledge-base/cctlds/pr.md
@@ -106,8 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/re.md
+++ b/scalar/content/tld-knowledge-base/cctlds/re.md
@@ -102,8 +102,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 12 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/ro.md
+++ b/scalar/content/tld-knowledge-base/cctlds/ro.md
@@ -101,8 +101,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 6 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/sc.md
+++ b/scalar/content/tld-knowledge-base/cctlds/sc.md
@@ -106,8 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/tf.md
+++ b/scalar/content/tld-knowledge-base/cctlds/tf.md
@@ -102,8 +102,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 12 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/tv.md
+++ b/scalar/content/tld-knowledge-base/cctlds/tv.md
@@ -106,8 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/uk.md
+++ b/scalar/content/tld-knowledge-base/cctlds/uk.md
@@ -106,8 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 1 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/us.md
+++ b/scalar/content/tld-knowledge-base/cctlds/us.md
@@ -106,8 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/vc.md
+++ b/scalar/content/tld-knowledge-base/cctlds/vc.md
@@ -106,8 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/vu.md
+++ b/scalar/content/tld-knowledge-base/cctlds/vu.md
@@ -106,8 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/wf.md
+++ b/scalar/content/tld-knowledge-base/cctlds/wf.md
@@ -102,8 +102,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 12 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/cctlds/yt.md
+++ b/scalar/content/tld-knowledge-base/cctlds/yt.md
@@ -102,8 +102,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 12 characters).
-- Note different status codes or dispute policies for ccTLDs.
-- Check if third-level structures (`co.uk`, etc.) need separate documentation.
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/academy.md
+++ b/scalar/content/tld-knowledge-base/gtlds/academy.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/accountants.md
+++ b/scalar/content/tld-knowledge-base/gtlds/accountants.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/actor.md
+++ b/scalar/content/tld-knowledge-base/gtlds/actor.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/ae.org.md
+++ b/scalar/content/tld-knowledge-base/gtlds/ae.org.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/agency.md
+++ b/scalar/content/tld-knowledge-base/gtlds/agency.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/airforce.md
+++ b/scalar/content/tld-knowledge-base/gtlds/airforce.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/apartments.md
+++ b/scalar/content/tld-knowledge-base/gtlds/apartments.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/app.md
+++ b/scalar/content/tld-knowledge-base/gtlds/app.md
@@ -108,6 +108,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 12 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/archi.md
+++ b/scalar/content/tld-knowledge-base/gtlds/archi.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/army.md
+++ b/scalar/content/tld-knowledge-base/gtlds/army.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/art.md
+++ b/scalar/content/tld-knowledge-base/gtlds/art.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/associates.md
+++ b/scalar/content/tld-knowledge-base/gtlds/associates.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/attorney.md
+++ b/scalar/content/tld-knowledge-base/gtlds/attorney.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/auction.md
+++ b/scalar/content/tld-knowledge-base/gtlds/auction.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/audio.md
+++ b/scalar/content/tld-knowledge-base/gtlds/audio.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/auto.md
+++ b/scalar/content/tld-knowledge-base/gtlds/auto.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/autos.md
+++ b/scalar/content/tld-knowledge-base/gtlds/autos.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/baby.md
+++ b/scalar/content/tld-knowledge-base/gtlds/baby.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/band.md
+++ b/scalar/content/tld-knowledge-base/gtlds/band.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/bar.md
+++ b/scalar/content/tld-knowledge-base/gtlds/bar.md
@@ -95,5 +95,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- AuthInfo must meet minimum requirements (≥ 6 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/bargains.md
+++ b/scalar/content/tld-knowledge-base/gtlds/bargains.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/bayern.md
+++ b/scalar/content/tld-knowledge-base/gtlds/bayern.md
@@ -95,5 +95,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- AuthInfo must meet minimum requirements (≥ 6 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/beer.md
+++ b/scalar/content/tld-knowledge-base/gtlds/beer.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/berlin.md
+++ b/scalar/content/tld-knowledge-base/gtlds/berlin.md
@@ -95,5 +95,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- AuthInfo must meet minimum requirements (≥ 6 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/bet.md
+++ b/scalar/content/tld-knowledge-base/gtlds/bet.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/bike.md
+++ b/scalar/content/tld-knowledge-base/gtlds/bike.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/bingo.md
+++ b/scalar/content/tld-knowledge-base/gtlds/bingo.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/bio.md
+++ b/scalar/content/tld-knowledge-base/gtlds/bio.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/biz.md
+++ b/scalar/content/tld-knowledge-base/gtlds/biz.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/black.md
+++ b/scalar/content/tld-knowledge-base/gtlds/black.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/blackfriday.md
+++ b/scalar/content/tld-knowledge-base/gtlds/blackfriday.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/blog.md
+++ b/scalar/content/tld-knowledge-base/gtlds/blog.md
@@ -95,5 +95,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- AuthInfo must meet minimum requirements (≥ 6 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/blue.md
+++ b/scalar/content/tld-knowledge-base/gtlds/blue.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/boats.md
+++ b/scalar/content/tld-knowledge-base/gtlds/boats.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/bond.md
+++ b/scalar/content/tld-knowledge-base/gtlds/bond.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/boo.md
+++ b/scalar/content/tld-knowledge-base/gtlds/boo.md
@@ -108,6 +108,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 12 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/boston.md
+++ b/scalar/content/tld-knowledge-base/gtlds/boston.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/boutique.md
+++ b/scalar/content/tld-knowledge-base/gtlds/boutique.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/br.com.md
+++ b/scalar/content/tld-knowledge-base/gtlds/br.com.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/broker.md
+++ b/scalar/content/tld-knowledge-base/gtlds/broker.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/build.md
+++ b/scalar/content/tld-knowledge-base/gtlds/build.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/builders.md
+++ b/scalar/content/tld-knowledge-base/gtlds/builders.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/business.md
+++ b/scalar/content/tld-knowledge-base/gtlds/business.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/cab.md
+++ b/scalar/content/tld-knowledge-base/gtlds/cab.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/cafe.md
+++ b/scalar/content/tld-knowledge-base/gtlds/cafe.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/camera.md
+++ b/scalar/content/tld-knowledge-base/gtlds/camera.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/camp.md
+++ b/scalar/content/tld-knowledge-base/gtlds/camp.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/capital.md
+++ b/scalar/content/tld-knowledge-base/gtlds/capital.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/car.md
+++ b/scalar/content/tld-knowledge-base/gtlds/car.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/cards.md
+++ b/scalar/content/tld-knowledge-base/gtlds/cards.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/care.md
+++ b/scalar/content/tld-knowledge-base/gtlds/care.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/careers.md
+++ b/scalar/content/tld-knowledge-base/gtlds/careers.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/cars.md
+++ b/scalar/content/tld-knowledge-base/gtlds/cars.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/casa.md
+++ b/scalar/content/tld-knowledge-base/gtlds/casa.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/cash.md
+++ b/scalar/content/tld-knowledge-base/gtlds/cash.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/casino.md
+++ b/scalar/content/tld-knowledge-base/gtlds/casino.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/catering.md
+++ b/scalar/content/tld-knowledge-base/gtlds/catering.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/center.md
+++ b/scalar/content/tld-knowledge-base/gtlds/center.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/ceo.md
+++ b/scalar/content/tld-knowledge-base/gtlds/ceo.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/cfd.md
+++ b/scalar/content/tld-knowledge-base/gtlds/cfd.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/channel.md
+++ b/scalar/content/tld-knowledge-base/gtlds/channel.md
@@ -108,6 +108,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 12 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/charity.md
+++ b/scalar/content/tld-knowledge-base/gtlds/charity.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/chat.md
+++ b/scalar/content/tld-knowledge-base/gtlds/chat.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/cheap.md
+++ b/scalar/content/tld-knowledge-base/gtlds/cheap.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/christmas.md
+++ b/scalar/content/tld-knowledge-base/gtlds/christmas.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/church.md
+++ b/scalar/content/tld-knowledge-base/gtlds/church.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/city.md
+++ b/scalar/content/tld-knowledge-base/gtlds/city.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/claims.md
+++ b/scalar/content/tld-knowledge-base/gtlds/claims.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/cleaning.md
+++ b/scalar/content/tld-knowledge-base/gtlds/cleaning.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/click.md
+++ b/scalar/content/tld-knowledge-base/gtlds/click.md
@@ -95,5 +95,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- AuthInfo must meet minimum requirements (≥ 6 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/clinic.md
+++ b/scalar/content/tld-knowledge-base/gtlds/clinic.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/clothing.md
+++ b/scalar/content/tld-knowledge-base/gtlds/clothing.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/cloud.md
+++ b/scalar/content/tld-knowledge-base/gtlds/cloud.md
@@ -95,5 +95,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- AuthInfo must meet minimum requirements (≥ 6 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/club.md
+++ b/scalar/content/tld-knowledge-base/gtlds/club.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/cn.com.md
+++ b/scalar/content/tld-knowledge-base/gtlds/cn.com.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/coach.md
+++ b/scalar/content/tld-knowledge-base/gtlds/coach.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/codes.md
+++ b/scalar/content/tld-knowledge-base/gtlds/codes.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/coffee.md
+++ b/scalar/content/tld-knowledge-base/gtlds/coffee.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/college.md
+++ b/scalar/content/tld-knowledge-base/gtlds/college.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/cologne.md
+++ b/scalar/content/tld-knowledge-base/gtlds/cologne.md
@@ -95,5 +95,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- AuthInfo must meet minimum requirements (≥ 6 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/com.md
+++ b/scalar/content/tld-knowledge-base/gtlds/com.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/community.md
+++ b/scalar/content/tld-knowledge-base/gtlds/community.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/company.md
+++ b/scalar/content/tld-knowledge-base/gtlds/company.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/compare.md
+++ b/scalar/content/tld-knowledge-base/gtlds/compare.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/computer.md
+++ b/scalar/content/tld-knowledge-base/gtlds/computer.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/condos.md
+++ b/scalar/content/tld-knowledge-base/gtlds/condos.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/construction.md
+++ b/scalar/content/tld-knowledge-base/gtlds/construction.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/consulting.md
+++ b/scalar/content/tld-knowledge-base/gtlds/consulting.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/contact.md
+++ b/scalar/content/tld-knowledge-base/gtlds/contact.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/contractors.md
+++ b/scalar/content/tld-knowledge-base/gtlds/contractors.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/cooking.md
+++ b/scalar/content/tld-knowledge-base/gtlds/cooking.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/cool.md
+++ b/scalar/content/tld-knowledge-base/gtlds/cool.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/coupons.md
+++ b/scalar/content/tld-knowledge-base/gtlds/coupons.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/courses.md
+++ b/scalar/content/tld-knowledge-base/gtlds/courses.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/credit.md
+++ b/scalar/content/tld-knowledge-base/gtlds/credit.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/creditcard.md
+++ b/scalar/content/tld-knowledge-base/gtlds/creditcard.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/cruises.md
+++ b/scalar/content/tld-knowledge-base/gtlds/cruises.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/cyou.md
+++ b/scalar/content/tld-knowledge-base/gtlds/cyou.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/dad.md
+++ b/scalar/content/tld-knowledge-base/gtlds/dad.md
@@ -108,6 +108,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 12 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/dance.md
+++ b/scalar/content/tld-knowledge-base/gtlds/dance.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/dating.md
+++ b/scalar/content/tld-knowledge-base/gtlds/dating.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/day.md
+++ b/scalar/content/tld-knowledge-base/gtlds/day.md
@@ -108,6 +108,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 12 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/de.com.md
+++ b/scalar/content/tld-knowledge-base/gtlds/de.com.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/deals.md
+++ b/scalar/content/tld-knowledge-base/gtlds/deals.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/degree.md
+++ b/scalar/content/tld-knowledge-base/gtlds/degree.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/delivery.md
+++ b/scalar/content/tld-knowledge-base/gtlds/delivery.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/democrat.md
+++ b/scalar/content/tld-knowledge-base/gtlds/democrat.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/dental.md
+++ b/scalar/content/tld-knowledge-base/gtlds/dental.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/dentist.md
+++ b/scalar/content/tld-knowledge-base/gtlds/dentist.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/design.md
+++ b/scalar/content/tld-knowledge-base/gtlds/design.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/dev.md
+++ b/scalar/content/tld-knowledge-base/gtlds/dev.md
@@ -108,6 +108,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 12 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/diamonds.md
+++ b/scalar/content/tld-knowledge-base/gtlds/diamonds.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/diet.md
+++ b/scalar/content/tld-knowledge-base/gtlds/diet.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/digital.md
+++ b/scalar/content/tld-knowledge-base/gtlds/digital.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/direct.md
+++ b/scalar/content/tld-knowledge-base/gtlds/direct.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/directory.md
+++ b/scalar/content/tld-knowledge-base/gtlds/directory.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/discount.md
+++ b/scalar/content/tld-knowledge-base/gtlds/discount.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/doctor.md
+++ b/scalar/content/tld-knowledge-base/gtlds/doctor.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/dog.md
+++ b/scalar/content/tld-knowledge-base/gtlds/dog.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/domains.md
+++ b/scalar/content/tld-knowledge-base/gtlds/domains.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/earth.md
+++ b/scalar/content/tld-knowledge-base/gtlds/earth.md
@@ -95,5 +95,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- AuthInfo must meet minimum requirements (≥ 6 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/education.md
+++ b/scalar/content/tld-knowledge-base/gtlds/education.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/email.md
+++ b/scalar/content/tld-knowledge-base/gtlds/email.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/energy.md
+++ b/scalar/content/tld-knowledge-base/gtlds/energy.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/engineer.md
+++ b/scalar/content/tld-knowledge-base/gtlds/engineer.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/engineering.md
+++ b/scalar/content/tld-knowledge-base/gtlds/engineering.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/enterprises.md
+++ b/scalar/content/tld-knowledge-base/gtlds/enterprises.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/equipment.md
+++ b/scalar/content/tld-knowledge-base/gtlds/equipment.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/esq.md
+++ b/scalar/content/tld-knowledge-base/gtlds/esq.md
@@ -108,6 +108,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 12 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/estate.md
+++ b/scalar/content/tld-knowledge-base/gtlds/estate.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/eu.com.md
+++ b/scalar/content/tld-knowledge-base/gtlds/eu.com.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/events.md
+++ b/scalar/content/tld-knowledge-base/gtlds/events.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/exchange.md
+++ b/scalar/content/tld-knowledge-base/gtlds/exchange.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/expert.md
+++ b/scalar/content/tld-knowledge-base/gtlds/expert.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/exposed.md
+++ b/scalar/content/tld-knowledge-base/gtlds/exposed.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/express.md
+++ b/scalar/content/tld-knowledge-base/gtlds/express.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/fail.md
+++ b/scalar/content/tld-knowledge-base/gtlds/fail.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/faith.md
+++ b/scalar/content/tld-knowledge-base/gtlds/faith.md
@@ -95,5 +95,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- AuthInfo must meet minimum requirements (≥ 6 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/family.md
+++ b/scalar/content/tld-knowledge-base/gtlds/family.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/fan.md
+++ b/scalar/content/tld-knowledge-base/gtlds/fan.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/farm.md
+++ b/scalar/content/tld-knowledge-base/gtlds/farm.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/fashion.md
+++ b/scalar/content/tld-knowledge-base/gtlds/fashion.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/finance.md
+++ b/scalar/content/tld-knowledge-base/gtlds/finance.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/financial.md
+++ b/scalar/content/tld-knowledge-base/gtlds/financial.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/fish.md
+++ b/scalar/content/tld-knowledge-base/gtlds/fish.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/fishing.md
+++ b/scalar/content/tld-knowledge-base/gtlds/fishing.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/fit.md
+++ b/scalar/content/tld-knowledge-base/gtlds/fit.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/fitness.md
+++ b/scalar/content/tld-knowledge-base/gtlds/fitness.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/flights.md
+++ b/scalar/content/tld-knowledge-base/gtlds/flights.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/florist.md
+++ b/scalar/content/tld-knowledge-base/gtlds/florist.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/flowers.md
+++ b/scalar/content/tld-knowledge-base/gtlds/flowers.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/foo.md
+++ b/scalar/content/tld-knowledge-base/gtlds/foo.md
@@ -108,6 +108,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 12 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/football.md
+++ b/scalar/content/tld-knowledge-base/gtlds/football.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/forex.md
+++ b/scalar/content/tld-knowledge-base/gtlds/forex.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/forsale.md
+++ b/scalar/content/tld-knowledge-base/gtlds/forsale.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/foundation.md
+++ b/scalar/content/tld-knowledge-base/gtlds/foundation.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/fun.md
+++ b/scalar/content/tld-knowledge-base/gtlds/fun.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/fund.md
+++ b/scalar/content/tld-knowledge-base/gtlds/fund.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/furniture.md
+++ b/scalar/content/tld-knowledge-base/gtlds/furniture.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/futbol.md
+++ b/scalar/content/tld-knowledge-base/gtlds/futbol.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/fyi.md
+++ b/scalar/content/tld-knowledge-base/gtlds/fyi.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/gallery.md
+++ b/scalar/content/tld-knowledge-base/gtlds/gallery.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/game.md
+++ b/scalar/content/tld-knowledge-base/gtlds/game.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/games.md
+++ b/scalar/content/tld-knowledge-base/gtlds/games.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/garden.md
+++ b/scalar/content/tld-knowledge-base/gtlds/garden.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/gay.md
+++ b/scalar/content/tld-knowledge-base/gtlds/gay.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/gb.net.md
+++ b/scalar/content/tld-knowledge-base/gtlds/gb.net.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/gifts.md
+++ b/scalar/content/tld-knowledge-base/gtlds/gifts.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/gives.md
+++ b/scalar/content/tld-knowledge-base/gtlds/gives.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/giving.md
+++ b/scalar/content/tld-knowledge-base/gtlds/giving.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/glass.md
+++ b/scalar/content/tld-knowledge-base/gtlds/glass.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/global.md
+++ b/scalar/content/tld-knowledge-base/gtlds/global.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/gmbh.md
+++ b/scalar/content/tld-knowledge-base/gtlds/gmbh.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/gold.md
+++ b/scalar/content/tld-knowledge-base/gtlds/gold.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/golf.md
+++ b/scalar/content/tld-knowledge-base/gtlds/golf.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/gr.com.md
+++ b/scalar/content/tld-knowledge-base/gtlds/gr.com.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/graphics.md
+++ b/scalar/content/tld-knowledge-base/gtlds/graphics.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/gratis.md
+++ b/scalar/content/tld-knowledge-base/gtlds/gratis.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/green.md
+++ b/scalar/content/tld-knowledge-base/gtlds/green.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/gripe.md
+++ b/scalar/content/tld-knowledge-base/gtlds/gripe.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/group.md
+++ b/scalar/content/tld-knowledge-base/gtlds/group.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/guide.md
+++ b/scalar/content/tld-knowledge-base/gtlds/guide.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/guitars.md
+++ b/scalar/content/tld-knowledge-base/gtlds/guitars.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/guru.md
+++ b/scalar/content/tld-knowledge-base/gtlds/guru.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/hair.md
+++ b/scalar/content/tld-knowledge-base/gtlds/hair.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/hamburg.md
+++ b/scalar/content/tld-knowledge-base/gtlds/hamburg.md
@@ -95,5 +95,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- AuthInfo must meet minimum requirements (≥ 6 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/haus.md
+++ b/scalar/content/tld-knowledge-base/gtlds/haus.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/health.md
+++ b/scalar/content/tld-knowledge-base/gtlds/health.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/healthcare.md
+++ b/scalar/content/tld-knowledge-base/gtlds/healthcare.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/help.md
+++ b/scalar/content/tld-knowledge-base/gtlds/help.md
@@ -95,5 +95,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- AuthInfo must meet minimum requirements (≥ 6 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/hockey.md
+++ b/scalar/content/tld-knowledge-base/gtlds/hockey.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/holdings.md
+++ b/scalar/content/tld-knowledge-base/gtlds/holdings.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/holiday.md
+++ b/scalar/content/tld-knowledge-base/gtlds/holiday.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/homes.md
+++ b/scalar/content/tld-knowledge-base/gtlds/homes.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/horse.md
+++ b/scalar/content/tld-knowledge-base/gtlds/horse.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/hospital.md
+++ b/scalar/content/tld-knowledge-base/gtlds/hospital.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/host.md
+++ b/scalar/content/tld-knowledge-base/gtlds/host.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/hosting.md
+++ b/scalar/content/tld-knowledge-base/gtlds/hosting.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/house.md
+++ b/scalar/content/tld-knowledge-base/gtlds/house.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/how.md
+++ b/scalar/content/tld-knowledge-base/gtlds/how.md
@@ -108,6 +108,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 12 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/hu.net.md
+++ b/scalar/content/tld-knowledge-base/gtlds/hu.net.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/icu.md
+++ b/scalar/content/tld-knowledge-base/gtlds/icu.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/immo.md
+++ b/scalar/content/tld-knowledge-base/gtlds/immo.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/immobilien.md
+++ b/scalar/content/tld-knowledge-base/gtlds/immobilien.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/industries.md
+++ b/scalar/content/tld-knowledge-base/gtlds/industries.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/info.md
+++ b/scalar/content/tld-knowledge-base/gtlds/info.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/ing.md
+++ b/scalar/content/tld-knowledge-base/gtlds/ing.md
@@ -108,6 +108,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 12 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/ink.md
+++ b/scalar/content/tld-knowledge-base/gtlds/ink.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/institute.md
+++ b/scalar/content/tld-knowledge-base/gtlds/institute.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/insure.md
+++ b/scalar/content/tld-knowledge-base/gtlds/insure.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/international.md
+++ b/scalar/content/tld-knowledge-base/gtlds/international.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/investments.md
+++ b/scalar/content/tld-knowledge-base/gtlds/investments.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/irish.md
+++ b/scalar/content/tld-knowledge-base/gtlds/irish.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/jetzt.md
+++ b/scalar/content/tld-knowledge-base/gtlds/jetzt.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/jewelry.md
+++ b/scalar/content/tld-knowledge-base/gtlds/jewelry.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/jp.net.md
+++ b/scalar/content/tld-knowledge-base/gtlds/jp.net.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/jpn.com.md
+++ b/scalar/content/tld-knowledge-base/gtlds/jpn.com.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/juegos.md
+++ b/scalar/content/tld-knowledge-base/gtlds/juegos.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/kaufen.md
+++ b/scalar/content/tld-knowledge-base/gtlds/kaufen.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/kim.md
+++ b/scalar/content/tld-knowledge-base/gtlds/kim.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/kitchen.md
+++ b/scalar/content/tld-knowledge-base/gtlds/kitchen.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/koeln.md
+++ b/scalar/content/tld-knowledge-base/gtlds/koeln.md
@@ -95,5 +95,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- AuthInfo must meet minimum requirements (≥ 6 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/land.md
+++ b/scalar/content/tld-knowledge-base/gtlds/land.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/lat.md
+++ b/scalar/content/tld-knowledge-base/gtlds/lat.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/law.md
+++ b/scalar/content/tld-knowledge-base/gtlds/law.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/lawyer.md
+++ b/scalar/content/tld-knowledge-base/gtlds/lawyer.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/lease.md
+++ b/scalar/content/tld-knowledge-base/gtlds/lease.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/legal.md
+++ b/scalar/content/tld-knowledge-base/gtlds/legal.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/lgbt.md
+++ b/scalar/content/tld-knowledge-base/gtlds/lgbt.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/life.md
+++ b/scalar/content/tld-knowledge-base/gtlds/life.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/lighting.md
+++ b/scalar/content/tld-knowledge-base/gtlds/lighting.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/limited.md
+++ b/scalar/content/tld-knowledge-base/gtlds/limited.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/limo.md
+++ b/scalar/content/tld-knowledge-base/gtlds/limo.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/link.md
+++ b/scalar/content/tld-knowledge-base/gtlds/link.md
@@ -99,6 +99,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/live.md
+++ b/scalar/content/tld-knowledge-base/gtlds/live.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/llc.md
+++ b/scalar/content/tld-knowledge-base/gtlds/llc.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/loans.md
+++ b/scalar/content/tld-knowledge-base/gtlds/loans.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/lol.md
+++ b/scalar/content/tld-knowledge-base/gtlds/lol.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/london.md
+++ b/scalar/content/tld-knowledge-base/gtlds/london.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/lotto.md
+++ b/scalar/content/tld-knowledge-base/gtlds/lotto.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/love.md
+++ b/scalar/content/tld-knowledge-base/gtlds/love.md
@@ -95,5 +95,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- AuthInfo must meet minimum requirements (≥ 6 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/ltd.md
+++ b/scalar/content/tld-knowledge-base/gtlds/ltd.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/luxe.md
+++ b/scalar/content/tld-knowledge-base/gtlds/luxe.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/maison.md
+++ b/scalar/content/tld-knowledge-base/gtlds/maison.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/makeup.md
+++ b/scalar/content/tld-knowledge-base/gtlds/makeup.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/management.md
+++ b/scalar/content/tld-knowledge-base/gtlds/management.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/market.md
+++ b/scalar/content/tld-knowledge-base/gtlds/market.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/marketing.md
+++ b/scalar/content/tld-knowledge-base/gtlds/marketing.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/markets.md
+++ b/scalar/content/tld-knowledge-base/gtlds/markets.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/mba.md
+++ b/scalar/content/tld-knowledge-base/gtlds/mba.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/media.md
+++ b/scalar/content/tld-knowledge-base/gtlds/media.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/meme.md
+++ b/scalar/content/tld-knowledge-base/gtlds/meme.md
@@ -108,6 +108,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 12 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/memorial.md
+++ b/scalar/content/tld-knowledge-base/gtlds/memorial.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/mex.com.md
+++ b/scalar/content/tld-knowledge-base/gtlds/mex.com.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/miami.md
+++ b/scalar/content/tld-knowledge-base/gtlds/miami.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/mobi.md
+++ b/scalar/content/tld-knowledge-base/gtlds/mobi.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/mobile.md
+++ b/scalar/content/tld-knowledge-base/gtlds/mobile.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/moda.md
+++ b/scalar/content/tld-knowledge-base/gtlds/moda.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/mom.md
+++ b/scalar/content/tld-knowledge-base/gtlds/mom.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/money.md
+++ b/scalar/content/tld-knowledge-base/gtlds/money.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/monster.md
+++ b/scalar/content/tld-knowledge-base/gtlds/monster.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/mortgage.md
+++ b/scalar/content/tld-knowledge-base/gtlds/mortgage.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/motorcycles.md
+++ b/scalar/content/tld-knowledge-base/gtlds/motorcycles.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/mov.md
+++ b/scalar/content/tld-knowledge-base/gtlds/mov.md
@@ -108,6 +108,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 12 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/movie.md
+++ b/scalar/content/tld-knowledge-base/gtlds/movie.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/music.md
+++ b/scalar/content/tld-knowledge-base/gtlds/music.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/name.md
+++ b/scalar/content/tld-knowledge-base/gtlds/name.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/navy.md
+++ b/scalar/content/tld-knowledge-base/gtlds/navy.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/net.md
+++ b/scalar/content/tld-knowledge-base/gtlds/net.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/network.md
+++ b/scalar/content/tld-knowledge-base/gtlds/network.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/new.md
+++ b/scalar/content/tld-knowledge-base/gtlds/new.md
@@ -107,6 +107,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 12 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/news.md
+++ b/scalar/content/tld-knowledge-base/gtlds/news.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/nexus.md
+++ b/scalar/content/tld-knowledge-base/gtlds/nexus.md
@@ -108,6 +108,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 12 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/ngo.md
+++ b/scalar/content/tld-knowledge-base/gtlds/ngo.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/ninja.md
+++ b/scalar/content/tld-knowledge-base/gtlds/ninja.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/nrw.md
+++ b/scalar/content/tld-knowledge-base/gtlds/nrw.md
@@ -95,5 +95,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- AuthInfo must meet minimum requirements (≥ 6 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/one.md
+++ b/scalar/content/tld-knowledge-base/gtlds/one.md
@@ -95,5 +95,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- AuthInfo must meet minimum requirements (≥ 6 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/ong.md
+++ b/scalar/content/tld-knowledge-base/gtlds/ong.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/online.md
+++ b/scalar/content/tld-knowledge-base/gtlds/online.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/org.md
+++ b/scalar/content/tld-knowledge-base/gtlds/org.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/organic.md
+++ b/scalar/content/tld-knowledge-base/gtlds/organic.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/page.md
+++ b/scalar/content/tld-knowledge-base/gtlds/page.md
@@ -108,6 +108,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 12 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/partners.md
+++ b/scalar/content/tld-knowledge-base/gtlds/partners.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/parts.md
+++ b/scalar/content/tld-knowledge-base/gtlds/parts.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/pet.md
+++ b/scalar/content/tld-knowledge-base/gtlds/pet.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/phd.md
+++ b/scalar/content/tld-knowledge-base/gtlds/phd.md
@@ -108,6 +108,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 12 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/photo.md
+++ b/scalar/content/tld-knowledge-base/gtlds/photo.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/photography.md
+++ b/scalar/content/tld-knowledge-base/gtlds/photography.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/photos.md
+++ b/scalar/content/tld-knowledge-base/gtlds/photos.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/pics.md
+++ b/scalar/content/tld-knowledge-base/gtlds/pics.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/pictures.md
+++ b/scalar/content/tld-knowledge-base/gtlds/pictures.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/pink.md
+++ b/scalar/content/tld-knowledge-base/gtlds/pink.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/pizza.md
+++ b/scalar/content/tld-knowledge-base/gtlds/pizza.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/place.md
+++ b/scalar/content/tld-knowledge-base/gtlds/place.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/plumbing.md
+++ b/scalar/content/tld-knowledge-base/gtlds/plumbing.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/plus.md
+++ b/scalar/content/tld-knowledge-base/gtlds/plus.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/poker.md
+++ b/scalar/content/tld-knowledge-base/gtlds/poker.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/press.md
+++ b/scalar/content/tld-knowledge-base/gtlds/press.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/pro.md
+++ b/scalar/content/tld-knowledge-base/gtlds/pro.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/productions.md
+++ b/scalar/content/tld-knowledge-base/gtlds/productions.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/prof.md
+++ b/scalar/content/tld-knowledge-base/gtlds/prof.md
@@ -108,6 +108,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 12 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/promo.md
+++ b/scalar/content/tld-knowledge-base/gtlds/promo.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/properties.md
+++ b/scalar/content/tld-knowledge-base/gtlds/properties.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/protection.md
+++ b/scalar/content/tld-knowledge-base/gtlds/protection.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/pub.md
+++ b/scalar/content/tld-knowledge-base/gtlds/pub.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/qpon.md
+++ b/scalar/content/tld-knowledge-base/gtlds/qpon.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/quest.md
+++ b/scalar/content/tld-knowledge-base/gtlds/quest.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/recipes.md
+++ b/scalar/content/tld-knowledge-base/gtlds/recipes.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/red.md
+++ b/scalar/content/tld-knowledge-base/gtlds/red.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/rehab.md
+++ b/scalar/content/tld-knowledge-base/gtlds/rehab.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/reise.md
+++ b/scalar/content/tld-knowledge-base/gtlds/reise.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/reisen.md
+++ b/scalar/content/tld-knowledge-base/gtlds/reisen.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/rent.md
+++ b/scalar/content/tld-knowledge-base/gtlds/rent.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/rentals.md
+++ b/scalar/content/tld-knowledge-base/gtlds/rentals.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/repair.md
+++ b/scalar/content/tld-knowledge-base/gtlds/repair.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/report.md
+++ b/scalar/content/tld-knowledge-base/gtlds/report.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/republican.md
+++ b/scalar/content/tld-knowledge-base/gtlds/republican.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/restaurant.md
+++ b/scalar/content/tld-knowledge-base/gtlds/restaurant.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/reviews.md
+++ b/scalar/content/tld-knowledge-base/gtlds/reviews.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/rip.md
+++ b/scalar/content/tld-knowledge-base/gtlds/rip.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/rocks.md
+++ b/scalar/content/tld-knowledge-base/gtlds/rocks.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/rodeo.md
+++ b/scalar/content/tld-knowledge-base/gtlds/rodeo.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/rsvp.md
+++ b/scalar/content/tld-knowledge-base/gtlds/rsvp.md
@@ -108,6 +108,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 12 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/ru.com.md
+++ b/scalar/content/tld-knowledge-base/gtlds/ru.com.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/ruhr.md
+++ b/scalar/content/tld-knowledge-base/gtlds/ruhr.md
@@ -95,5 +95,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- AuthInfo must meet minimum requirements (≥ 6 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/run.md
+++ b/scalar/content/tld-knowledge-base/gtlds/run.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/sa.com.md
+++ b/scalar/content/tld-knowledge-base/gtlds/sa.com.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/saarland.md
+++ b/scalar/content/tld-knowledge-base/gtlds/saarland.md
@@ -95,5 +95,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- AuthInfo must meet minimum requirements (≥ 6 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/sale.md
+++ b/scalar/content/tld-knowledge-base/gtlds/sale.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/salon.md
+++ b/scalar/content/tld-knowledge-base/gtlds/salon.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/sarl.md
+++ b/scalar/content/tld-knowledge-base/gtlds/sarl.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/sbs.md
+++ b/scalar/content/tld-knowledge-base/gtlds/sbs.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/school.md
+++ b/scalar/content/tld-knowledge-base/gtlds/school.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/schule.md
+++ b/scalar/content/tld-knowledge-base/gtlds/schule.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/se.net.md
+++ b/scalar/content/tld-knowledge-base/gtlds/se.net.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/security.md
+++ b/scalar/content/tld-knowledge-base/gtlds/security.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/select.md
+++ b/scalar/content/tld-knowledge-base/gtlds/select.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/services.md
+++ b/scalar/content/tld-knowledge-base/gtlds/services.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/sexy.md
+++ b/scalar/content/tld-knowledge-base/gtlds/sexy.md
@@ -95,5 +95,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- AuthInfo must meet minimum requirements (≥ 6 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/shiksha.md
+++ b/scalar/content/tld-knowledge-base/gtlds/shiksha.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/shoes.md
+++ b/scalar/content/tld-knowledge-base/gtlds/shoes.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/shop.md
+++ b/scalar/content/tld-knowledge-base/gtlds/shop.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 12 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/shopping.md
+++ b/scalar/content/tld-knowledge-base/gtlds/shopping.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/show.md
+++ b/scalar/content/tld-knowledge-base/gtlds/show.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/singles.md
+++ b/scalar/content/tld-knowledge-base/gtlds/singles.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/site.md
+++ b/scalar/content/tld-knowledge-base/gtlds/site.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/ski.md
+++ b/scalar/content/tld-knowledge-base/gtlds/ski.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/skin.md
+++ b/scalar/content/tld-knowledge-base/gtlds/skin.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/soccer.md
+++ b/scalar/content/tld-knowledge-base/gtlds/soccer.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/social.md
+++ b/scalar/content/tld-knowledge-base/gtlds/social.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/software.md
+++ b/scalar/content/tld-knowledge-base/gtlds/software.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/solar.md
+++ b/scalar/content/tld-knowledge-base/gtlds/solar.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/solutions.md
+++ b/scalar/content/tld-knowledge-base/gtlds/solutions.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/soy.md
+++ b/scalar/content/tld-knowledge-base/gtlds/soy.md
@@ -108,6 +108,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 12 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/space.md
+++ b/scalar/content/tld-knowledge-base/gtlds/space.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/storage.md
+++ b/scalar/content/tld-knowledge-base/gtlds/storage.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/store.md
+++ b/scalar/content/tld-knowledge-base/gtlds/store.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/studio.md
+++ b/scalar/content/tld-knowledge-base/gtlds/studio.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/study.md
+++ b/scalar/content/tld-knowledge-base/gtlds/study.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/style.md
+++ b/scalar/content/tld-knowledge-base/gtlds/style.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/supplies.md
+++ b/scalar/content/tld-knowledge-base/gtlds/supplies.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/supply.md
+++ b/scalar/content/tld-knowledge-base/gtlds/supply.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/support.md
+++ b/scalar/content/tld-knowledge-base/gtlds/support.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/surf.md
+++ b/scalar/content/tld-knowledge-base/gtlds/surf.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/surgery.md
+++ b/scalar/content/tld-knowledge-base/gtlds/surgery.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/systems.md
+++ b/scalar/content/tld-knowledge-base/gtlds/systems.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/tattoo.md
+++ b/scalar/content/tld-knowledge-base/gtlds/tattoo.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/tax.md
+++ b/scalar/content/tld-knowledge-base/gtlds/tax.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/taxi.md
+++ b/scalar/content/tld-knowledge-base/gtlds/taxi.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/team.md
+++ b/scalar/content/tld-knowledge-base/gtlds/team.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/tech.md
+++ b/scalar/content/tld-knowledge-base/gtlds/tech.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/technology.md
+++ b/scalar/content/tld-knowledge-base/gtlds/technology.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/tel.md
+++ b/scalar/content/tld-knowledge-base/gtlds/tel.md
@@ -95,5 +95,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- AuthInfo must meet minimum requirements (≥ 6 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/tennis.md
+++ b/scalar/content/tld-knowledge-base/gtlds/tennis.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/theater.md
+++ b/scalar/content/tld-knowledge-base/gtlds/theater.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/theatre.md
+++ b/scalar/content/tld-knowledge-base/gtlds/theatre.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/tickets.md
+++ b/scalar/content/tld-knowledge-base/gtlds/tickets.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/tienda.md
+++ b/scalar/content/tld-knowledge-base/gtlds/tienda.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/tips.md
+++ b/scalar/content/tld-knowledge-base/gtlds/tips.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/tires.md
+++ b/scalar/content/tld-knowledge-base/gtlds/tires.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/today.md
+++ b/scalar/content/tld-knowledge-base/gtlds/today.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/tools.md
+++ b/scalar/content/tld-knowledge-base/gtlds/tools.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/tours.md
+++ b/scalar/content/tld-knowledge-base/gtlds/tours.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/town.md
+++ b/scalar/content/tld-knowledge-base/gtlds/town.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/toys.md
+++ b/scalar/content/tld-knowledge-base/gtlds/toys.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/trade.md
+++ b/scalar/content/tld-knowledge-base/gtlds/trade.md
@@ -95,5 +95,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- AuthInfo must meet minimum requirements (≥ 6 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/trading.md
+++ b/scalar/content/tld-knowledge-base/gtlds/trading.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/training.md
+++ b/scalar/content/tld-knowledge-base/gtlds/training.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/travel.md
+++ b/scalar/content/tld-knowledge-base/gtlds/travel.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/uk.com.md
+++ b/scalar/content/tld-knowledge-base/gtlds/uk.com.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/uk.net.md
+++ b/scalar/content/tld-knowledge-base/gtlds/uk.net.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/university.md
+++ b/scalar/content/tld-knowledge-base/gtlds/university.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/uno.md
+++ b/scalar/content/tld-knowledge-base/gtlds/uno.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/us.com.md
+++ b/scalar/content/tld-knowledge-base/gtlds/us.com.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/us.org.md
+++ b/scalar/content/tld-knowledge-base/gtlds/us.org.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/vacations.md
+++ b/scalar/content/tld-knowledge-base/gtlds/vacations.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/ventures.md
+++ b/scalar/content/tld-knowledge-base/gtlds/ventures.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/vet.md
+++ b/scalar/content/tld-knowledge-base/gtlds/vet.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/viajes.md
+++ b/scalar/content/tld-knowledge-base/gtlds/viajes.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/video.md
+++ b/scalar/content/tld-knowledge-base/gtlds/video.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/villas.md
+++ b/scalar/content/tld-knowledge-base/gtlds/villas.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/vin.md
+++ b/scalar/content/tld-knowledge-base/gtlds/vin.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/vip.md
+++ b/scalar/content/tld-knowledge-base/gtlds/vip.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/vision.md
+++ b/scalar/content/tld-knowledge-base/gtlds/vision.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/vodka.md
+++ b/scalar/content/tld-knowledge-base/gtlds/vodka.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/vote.md
+++ b/scalar/content/tld-knowledge-base/gtlds/vote.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/voto.md
+++ b/scalar/content/tld-knowledge-base/gtlds/voto.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/voyage.md
+++ b/scalar/content/tld-knowledge-base/gtlds/voyage.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/watch.md
+++ b/scalar/content/tld-knowledge-base/gtlds/watch.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/watches.md
+++ b/scalar/content/tld-knowledge-base/gtlds/watches.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/website.md
+++ b/scalar/content/tld-knowledge-base/gtlds/website.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/wedding.md
+++ b/scalar/content/tld-knowledge-base/gtlds/wedding.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/wiki.md
+++ b/scalar/content/tld-knowledge-base/gtlds/wiki.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/wine.md
+++ b/scalar/content/tld-knowledge-base/gtlds/wine.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/work.md
+++ b/scalar/content/tld-knowledge-base/gtlds/work.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/works.md
+++ b/scalar/content/tld-knowledge-base/gtlds/works.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/world.md
+++ b/scalar/content/tld-knowledge-base/gtlds/world.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/wtf.md
+++ b/scalar/content/tld-knowledge-base/gtlds/wtf.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/xn--c1avg.md
+++ b/scalar/content/tld-knowledge-base/gtlds/xn--c1avg.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/xn--i1b6b1a6a2e.md
+++ b/scalar/content/tld-knowledge-base/gtlds/xn--i1b6b1a6a2e.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/xn--nqv7f.md
+++ b/scalar/content/tld-knowledge-base/gtlds/xn--nqv7f.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/xn--q9jyb4c.md
+++ b/scalar/content/tld-knowledge-base/gtlds/xn--q9jyb4c.md
@@ -108,6 +108,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 12 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/xyz.md
+++ b/scalar/content/tld-knowledge-base/gtlds/xyz.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/yachts.md
+++ b/scalar/content/tld-knowledge-base/gtlds/yachts.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/yoga.md
+++ b/scalar/content/tld-knowledge-base/gtlds/yoga.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/za.com.md
+++ b/scalar/content/tld-knowledge-base/gtlds/za.com.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/zip.md
+++ b/scalar/content/tld-knowledge-base/gtlds/zip.md
@@ -108,6 +108,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 12 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/zone.md
+++ b/scalar/content/tld-knowledge-base/gtlds/zone.md
@@ -106,6 +106,7 @@
 
 ## Implementation Notes
 
-- Ensure complete TLS/SSL configuration in all environments.
-- DNSSEC should be actively used when supported.
-- AuthInfo must meet minimum requirements (≥ 8 characters).
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scripts/generate_tld_knowledge_base.py
+++ b/scripts/generate_tld_knowledge_base.py
@@ -88,6 +88,38 @@ def load_specs(
     return specs
 
 
+NOTES_DIRNAME = "_notes"
+DEFAULT_NOTES_NAME = "_default.md"
+
+
+def load_notes(output_dir: Path, slug: str) -> str:
+    """Return the trailing notes block for a TLD, or "".
+
+    Looks for a per-TLD ``_notes/<slug>.md`` and falls back to
+    ``_notes/_default.md``. A file counts as present only when it has
+    non-whitespace content; an existing-but-blank per-TLD file is treated as a
+    mistake (it warns and falls back to the default) rather than silently
+    suppressing notes. The returned text is normalised so it always starts on
+    its own blank line and ends with a single trailing newline, keeping page
+    output idempotent regardless of the source file's surrounding whitespace.
+    """
+    notes_dir = output_dir / NOTES_DIRNAME
+    per_tld = notes_dir / f"{slug}.md"
+    for candidate in (per_tld, notes_dir / DEFAULT_NOTES_NAME):
+        if not candidate.exists():
+            continue
+        raw = candidate.read_text(encoding="utf-8")
+        if raw.strip():
+            return f"\n{raw.strip(chr(10))}\n"
+        if candidate == per_tld:
+            print(
+                f"::warning::{candidate} exists but is empty; "
+                f"falling back to {DEFAULT_NOTES_NAME}",
+                file=sys.stderr,
+            )
+    return ""
+
+
 def write_pages(
     specs: Iterable[tuple[Path, dict]],
     output_dir: Path,
@@ -102,7 +134,7 @@ def write_pages(
             continue
         category = render.page_category(spec)
         title = render.page_title(spec)
-        markdown = render.render(spec)
+        markdown = render.render(spec) + load_notes(output_dir, slug)
         target = output_dir / category / f"{slug}.md"
         if dry_run:
             print(f"[dry-run] would write {target.relative_to(output_dir.parent)}")
@@ -144,6 +176,13 @@ def main(argv: list[str] | None = None) -> int:
     if not specs:
         print("No matching compiled spec files found.", file=sys.stderr)
         return 1
+
+    if not (args.output / NOTES_DIRNAME / DEFAULT_NOTES_NAME).exists():
+        print(
+            f"::warning::{args.output / NOTES_DIRNAME / DEFAULT_NOTES_NAME} not found; "
+            "pages without their own _notes file will have no closing notes section",
+            file=sys.stderr,
+        )
 
     entries = write_pages(specs, args.output, dry_run=args.dry_run)
     keep = {(category, slug) for category, slug, _ in entries}

--- a/scripts/test_generate_tld_knowledge_base.py
+++ b/scripts/test_generate_tld_knowledge_base.py
@@ -1,0 +1,55 @@
+"""Unit tests for the notes-merge logic in ``generate_tld_knowledge_base``.
+
+Run from the ``scripts/`` directory (or repo root) with ``python -m pytest``.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from generate_tld_knowledge_base import DEFAULT_NOTES_NAME, NOTES_DIRNAME, load_notes
+
+
+def _write(output_dir: Path, name: str, content: str) -> None:
+    notes_dir = output_dir / NOTES_DIRNAME
+    notes_dir.mkdir(parents=True, exist_ok=True)
+    (notes_dir / name).write_text(content, encoding="utf-8")
+
+
+def test_per_tld_file_overrides_default(tmp_path: Path) -> None:
+    _write(tmp_path, "ca.md", "## CA\n\nca body\n")
+    _write(tmp_path, DEFAULT_NOTES_NAME, "## Default\n\ndefault body\n")
+    result = load_notes(tmp_path, "ca")
+    assert "ca body" in result
+    assert "default body" not in result
+
+
+def test_falls_back_to_default_when_no_per_tld_file(tmp_path: Path) -> None:
+    _write(tmp_path, DEFAULT_NOTES_NAME, "## Default\n\ndefault body\n")
+    assert "default body" in load_notes(tmp_path, "xyz")
+
+
+def test_returns_empty_when_no_notes_exist(tmp_path: Path) -> None:
+    assert load_notes(tmp_path, "xyz") == ""
+
+
+def test_empty_per_tld_file_warns_and_falls_back(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    _write(tmp_path, "ca.md", "\n   \n")
+    _write(tmp_path, DEFAULT_NOTES_NAME, "## Default\n\ndefault body\n")
+    result = load_notes(tmp_path, "ca")
+    assert "default body" in result
+    assert "exists but is empty" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("raw", ["body", "\n\nbody\n\n\n", "\nbody\n"])
+def test_surrounding_whitespace_normalises_to_single_separators(tmp_path: Path, raw: str) -> None:
+    _write(tmp_path, DEFAULT_NOTES_NAME, raw)
+    assert load_notes(tmp_path, "xyz") == "\nbody\n"
+
+
+def test_append_is_idempotent_against_render_output(tmp_path: Path) -> None:
+    _write(tmp_path, DEFAULT_NOTES_NAME, "## Notes\n\nbody\n")
+    page = "# Title\n\n## Section\n\nrow\n"  # render() ends with a single trailing newline
+    merged = page + load_notes(tmp_path, "xyz")
+    assert merged == "# Title\n\n## Section\n\nrow\n\n## Notes\n\nbody\n"
+    assert merged == page + load_notes(tmp_path, "xyz")

--- a/scripts/tld_knowledge_base/README.md
+++ b/scripts/tld_knowledge_base/README.md
@@ -22,9 +22,27 @@ Generated content lives in:
 
 ```
 scalar/content/tld-knowledge-base/
-├── cctlds/<tld>.md   # country-code TLDs
-└── gtlds/<tld>.md    # generic TLDs
+├── cctlds/<tld>.md   # country-code TLDs (generated)
+├── gtlds/<tld>.md    # generic TLDs (generated)
+└── _notes/           # hand-authored, appended to each page (not generated)
+    ├── _default.md   # used when a TLD has no notes file of its own
+    └── <tld>.md      # per-TLD override (e.g. ca.md)
 ```
+
+## Notes (the closing section of each page)
+
+The generated tables are spec-derived and overwritten on every run, so they are
+not the place for prose. Instead, each page's closing section is sourced from a
+hand-authored Markdown file under `_notes/` and appended verbatim during
+generation:
+
+- `_notes/<tld>.md` if it exists, otherwise `_notes/_default.md`.
+- Files in `_notes/` are inputs — they are never pruned or regenerated, and they
+  are not registered as Scalar routes, so they only ever appear *inside* the TLD
+  page they are merged into.
+- Author whatever `##` sections you like (e.g. `ca.md` documents the
+  `CIRA_CPR` Canadian Presence Requirement legal types). A per-TLD file fully
+  replaces the default — it does not stack on top of it.
 
 ## Local usage
 

--- a/scripts/tld_knowledge_base/render.py
+++ b/scripts/tld_knowledge_base/render.py
@@ -388,31 +388,6 @@ def _local_presence(config: dict[str, Any]) -> list[str]:
     return _section("Local Presence", rows)
 
 
-def _implementation_notes(config: dict[str, Any]) -> list[str]:
-    dns = config.get("dns_configuration") or {}
-    transfer = config.get("transfer_policies") or {}
-    info_type = (_first(config.get("tlds")) or {}).get("type", "").lower()
-
-    notes: list[str] = ["- Ensure complete TLS/SSL configuration in all environments."]
-
-    if dns.get("dnssec_mandatory"):
-        notes.append("- DNSSEC is mandatory and must be configured at registration time.")
-    elif dns.get("dnssec_allowed"):
-        notes.append("- DNSSEC should be actively used when supported.")
-
-    min_len = transfer.get("authinfo_min_length")
-    if min_len:
-        notes.append(f"- AuthInfo must meet minimum requirements (≥ {min_len} characters).")
-
-    if info_type == "cctld":
-        notes.append("- Note different status codes or dispute policies for ccTLDs.")
-        notes.append(
-            "- Check if third-level structures (`co.uk`, etc.) need separate documentation."
-        )
-
-    return ["## Implementation Notes", "", *notes, ""]
-
-
 # ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
@@ -438,7 +413,6 @@ def render(spec: dict[str, Any]) -> str:
     lines.extend(_whois_and_rdap(config))
     lines.extend(_dispute_resolution(config))
     lines.extend(_local_presence(config))
-    lines.extend(_implementation_notes(config))
 
     # Normalise: collapse trailing blank lines and ensure a single newline EOF.
     while lines and lines[-1] == "":


### PR DESCRIPTION
## Summary

Adds a per-TLD **notes** mechanism to the TLD Knowledge Base generator, and regenerates the full KB to use it.

- The spec-derived **Implementation Notes** section is removed from `render.py` (its facts already appear in the tables above). Each page's closing section now comes from a hand-authored file under `scalar/content/tld-knowledge-base/_notes/`, appended at generation time:
  - `_notes/<tld>.md` if present, else `_notes/_default.md`.
  - `_notes/` is never pruned and isn't a Scalar route — content only appears inside the page it's merged into.
- New `_notes/ca.md` documents the `CIRA_CPR` Canadian Presence Requirement legal types (descriptions per CIRA's published list).
- `load_notes` warns when a per-TLD file exists but is empty; the generator warns if `_default.md` is missing (since notes are now the only source for that section).

## Scope — full regeneration

This regenerates **all 467 pages**. For every page except `.ca`, the only change is the closing notes section: the old spec-derived Implementation Notes bullets become the shared `_default.md` block. `.ca` additionally gains the Contact Attributes / Canadian Presence Requirement sections from `_notes/ca.md`.

Verified the diff carries **no** incidental noise: no `IDN Support` line changes, no route/sidebar changes (`scalar.config.json` is byte-identical to main), and removed lines are exclusively old Implementation Notes content. Output is idempotent (re-running the generator produces no diff).

## Test

- `scripts/test_generate_tld_knowledge_base.py` covers `load_notes` (per-TLD override, default fallback, empty/whitespace handling, normalization, idempotency). Run: `python -m pytest scripts/`.
- `scalar project check-config` passes.