### PR TITLE
Fix TLD flags to use actual country codes instead of operator country

### DIFF
--- a/scalar/content/tld-knowledge-base/cctlds/ag.md
+++ b/scalar/content/tld-knowledge-base/cctlds/ag.md
@@ -1,4 +1,4 @@
-# 🇺🇸 .ag — United States
+# 🇦🇬 .ag — Antigua and Barbuda
 
 > The **.ag** is a country-code top-level domain (ccTLD) operated by Identity Digital Inc.. This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
 

--- a/scalar/content/tld-knowledge-base/cctlds/ai.md
+++ b/scalar/content/tld-knowledge-base/cctlds/ai.md
@@ -1,4 +1,4 @@
-# 🇺🇸 .ai — United States
+# 🇦🇮 .ai — Anguilla
 
 > The **.ai** is a country-code top-level domain (ccTLD) operated by Identity Digital Inc.. This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
 

--- a/scalar/content/tld-knowledge-base/cctlds/bz.md
+++ b/scalar/content/tld-knowledge-base/cctlds/bz.md
@@ -1,4 +1,4 @@
-# 🇺🇸 .bz — United States
+# 🇧🇿 .bz — Belize
 
 > The **.bz** is a country-code top-level domain (ccTLD) operated by Identity Digital Inc.. This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
 

--- a/scalar/content/tld-knowledge-base/cctlds/cc.md
+++ b/scalar/content/tld-knowledge-base/cctlds/cc.md
@@ -1,4 +1,4 @@
-# 🇦🇺 .cc — Australia
+# 🇨🇨 .cc — Cocos (Keeling) Islands
 
 > The **.cc** is a country-code top-level domain (ccTLD) operated by eNIC Cocos (Keeling) Islands Pty.. This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
 

--- a/scalar/content/tld-knowledge-base/cctlds/co.md
+++ b/scalar/content/tld-knowledge-base/cctlds/co.md
@@ -1,4 +1,4 @@
-# 🇬🇧 .co — United Kingdom
+# 🇨🇴 .co — Colombia
 
 > The **.co** is a country-code top-level domain (ccTLD) operated by CentralNic Group PLC. This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
 

--- a/scalar/content/tld-knowledge-base/cctlds/com.de.md
+++ b/scalar/content/tld-knowledge-base/cctlds/com.de.md
@@ -1,4 +1,4 @@
-# 🇬🇧 .com.de — United Kingdom
+# 🇩🇪 .com.de — Germany
 
 > The **.com.de** is a country-code top-level domain (ccTLD) operated by CentralNic Group PLC. This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
 

--- a/scalar/content/tld-knowledge-base/cctlds/com.se.md
+++ b/scalar/content/tld-knowledge-base/cctlds/com.se.md
@@ -1,4 +1,4 @@
-# 🇬🇧 .com.se — United Kingdom
+# 🇸🇪 .com.se — Sweden
 
 > The **.com.se** is a country-code top-level domain (ccTLD) operated by CentralNic Group PLC. This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
 

--- a/scalar/content/tld-knowledge-base/cctlds/eu.md
+++ b/scalar/content/tld-knowledge-base/cctlds/eu.md
@@ -1,4 +1,4 @@
-# 🇧🇪 .eu — Belgium
+# 🇪🇺 .eu — European Union
 
 > The **.eu** is a country-code top-level domain (ccTLD) operated by EURid vzw/asbl. This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
 

--- a/scalar/content/tld-knowledge-base/cctlds/io.md
+++ b/scalar/content/tld-knowledge-base/cctlds/io.md
@@ -1,4 +1,4 @@
-# 🇺🇸 .io — United States
+# 🇮🇴 .io — British Indian Ocean Territory
 
 > The **.io** is a country-code top-level domain (ccTLD) operated by Identity Digital Inc.. This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
 

--- a/scalar/content/tld-knowledge-base/cctlds/lc.md
+++ b/scalar/content/tld-knowledge-base/cctlds/lc.md
@@ -1,4 +1,4 @@
-# 🇺🇸 .lc — United States
+# 🇱🇨 .lc — Saint Lucia
 
 > The **.lc** is a country-code top-level domain (ccTLD) operated by Identity Digital Inc.. This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
 

--- a/scalar/content/tld-knowledge-base/cctlds/li.md
+++ b/scalar/content/tld-knowledge-base/cctlds/li.md
@@ -1,4 +1,4 @@
-# 🇨🇭 .li — Switzerland
+# 🇱🇮 .li — Liechtenstein
 
 > The **.li** is a country-code top-level domain (ccTLD) operated by Switch. This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
 

--- a/scalar/content/tld-knowledge-base/cctlds/me.md
+++ b/scalar/content/tld-knowledge-base/cctlds/me.md
@@ -1,4 +1,4 @@
-# 🇺🇸 .me — United States
+# 🇲🇪 .me — Montenegro
 
 > The **.me** is a country-code top-level domain (ccTLD) operated by Identity Digital Inc.. This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
 

--- a/scalar/content/tld-knowledge-base/cctlds/mn.md
+++ b/scalar/content/tld-knowledge-base/cctlds/mn.md
@@ -1,4 +1,4 @@
-# 🇺🇸 .mn — United States
+# 🇲🇳 .mn — Mongolia
 
 > The **.mn** is a country-code top-level domain (ccTLD) operated by Identity Digital Inc.. This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
 

--- a/scalar/content/tld-knowledge-base/cctlds/pm.md
+++ b/scalar/content/tld-knowledge-base/cctlds/pm.md
@@ -1,4 +1,4 @@
-# 🇫🇷 .pm — France
+# 🇵🇲 .pm — Saint Pierre and Miquelon
 
 > The **.pm** is a country-code top-level domain (ccTLD) operated by AFNIC (Association Française pour le Nommage Internet en Coopération). This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
 

--- a/scalar/content/tld-knowledge-base/cctlds/pr.md
+++ b/scalar/content/tld-knowledge-base/cctlds/pr.md
@@ -1,4 +1,4 @@
-# 🇺🇸 .pr — United States
+# 🇵🇷 .pr — Puerto Rico
 
 > The **.pr** is a country-code top-level domain (ccTLD) operated by Identity Digital Inc.. This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
 

--- a/scalar/content/tld-knowledge-base/cctlds/re.md
+++ b/scalar/content/tld-knowledge-base/cctlds/re.md
@@ -1,4 +1,4 @@
-# 🇫🇷 .re — France
+# 🇷🇪 .re — Réunion
 
 > The **.re** is a country-code top-level domain (ccTLD) operated by AFNIC (Association Française pour le Nommage Internet en Coopération). This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
 

--- a/scalar/content/tld-knowledge-base/cctlds/sc.md
+++ b/scalar/content/tld-knowledge-base/cctlds/sc.md
@@ -1,4 +1,4 @@
-# 🇺🇸 .sc — United States
+# 🇸🇨 .sc — Seychelles
 
 > The **.sc** is a country-code top-level domain (ccTLD) operated by Identity Digital Inc.. This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
 

--- a/scalar/content/tld-knowledge-base/cctlds/tf.md
+++ b/scalar/content/tld-knowledge-base/cctlds/tf.md
@@ -1,4 +1,4 @@
-# 🇫🇷 .tf — France
+# 🇹🇫 .tf — French Southern Territories
 
 > The **.tf** is a country-code top-level domain (ccTLD) operated by AFNIC (Association Française pour le Nommage Internet en Coopération). This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
 

--- a/scalar/content/tld-knowledge-base/cctlds/vc.md
+++ b/scalar/content/tld-knowledge-base/cctlds/vc.md
@@ -1,4 +1,4 @@
-# 🇺🇸 .vc — United States
+# 🇻🇨 .vc — Saint Vincent and the Grenadines
 
 > The **.vc** is a country-code top-level domain (ccTLD) operated by Identity Digital Inc.. This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
 

--- a/scalar/content/tld-knowledge-base/cctlds/wf.md
+++ b/scalar/content/tld-knowledge-base/cctlds/wf.md
@@ -1,4 +1,4 @@
-# 🇫🇷 .wf — France
+# 🇼🇫 .wf — Wallis and Futuna
 
 > The **.wf** is a country-code top-level domain (ccTLD) operated by AFNIC (Association Française pour le Nommage Internet en Coopération). This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
 

--- a/scalar/content/tld-knowledge-base/cctlds/yt.md
+++ b/scalar/content/tld-knowledge-base/cctlds/yt.md
@@ -1,4 +1,4 @@
-# 🇫🇷 .yt — France
+# 🇾🇹 .yt — Mayotte
 
 > The **.yt** is a country-code top-level domain (ccTLD) operated by AFNIC (Association Française pour le Nommage Internet en Coopération). This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
 

--- a/scalar/scalar.config.json
+++ b/scalar/scalar.config.json
@@ -791,12 +791,6 @@
                 "filepath": "content/tld-knowledge-base/cctlds/tv.md",
                 "showInSidebar": true
               },
-              "/ua": {
-                "type": "page",
-                "title": "🇺🇦 .ua",
-                "filepath": "content/tld-knowledge-base/cctlds/ua.md",
-                "showInSidebar": true
-              },
               "/uk": {
                 "type": "page",
                 "title": "🇬🇧 .uk",

--- a/scalar/scalar.config.json
+++ b/scalar/scalar.config.json
@@ -751,7 +751,7 @@
               },
               "/pm": {
                 "type": "page",
-                "title": "🇫🇷 .pm",
+                "title": "🇵🇲 .pm",
                 "filepath": "content/tld-knowledge-base/cctlds/pm.md",
                 "showInSidebar": true
               },

--- a/scalar/scalar.config.json
+++ b/scalar/scalar.config.json
@@ -595,13 +595,13 @@
             "children": {
               "/ag": {
                 "type": "page",
-                "title": "🇺🇸 .ag",
+                "title": "🇦🇬 .ag",
                 "filepath": "content/tld-knowledge-base/cctlds/ag.md",
                 "showInSidebar": true
               },
               "/ai": {
                 "type": "page",
-                "title": "🇺🇸 .ai",
+                "title": "🇦🇮 .ai",
                 "filepath": "content/tld-knowledge-base/cctlds/ai.md",
                 "showInSidebar": true
               },
@@ -619,7 +619,7 @@
               },
               "/bz": {
                 "type": "page",
-                "title": "🇺🇸 .bz",
+                "title": "🇧🇿 .bz",
                 "filepath": "content/tld-knowledge-base/cctlds/bz.md",
                 "showInSidebar": true
               },
@@ -631,7 +631,7 @@
               },
               "/cc": {
                 "type": "page",
-                "title": "🇦🇺 .cc",
+                "title": "🇨🇨 .cc",
                 "filepath": "content/tld-knowledge-base/cctlds/cc.md",
                 "showInSidebar": true
               },
@@ -643,19 +643,19 @@
               },
               "/co": {
                 "type": "page",
-                "title": "🇬🇧 .co",
+                "title": "🇨🇴 .co",
                 "filepath": "content/tld-knowledge-base/cctlds/co.md",
                 "showInSidebar": true
               },
               "/com.de": {
                 "type": "page",
-                "title": "🇬🇧 .com.de",
+                "title": "🇩🇪 .com.de",
                 "filepath": "content/tld-knowledge-base/cctlds/com.de.md",
                 "showInSidebar": true
               },
               "/com.se": {
                 "type": "page",
-                "title": "🇬🇧 .com.se",
+                "title": "🇸🇪 .com.se",
                 "filepath": "content/tld-knowledge-base/cctlds/com.se.md",
                 "showInSidebar": true
               },
@@ -679,7 +679,7 @@
               },
               "/eu": {
                 "type": "page",
-                "title": "🇧🇪 .eu",
+                "title": "🇪🇺 .eu",
                 "filepath": "content/tld-knowledge-base/cctlds/eu.md",
                 "showInSidebar": true
               },
@@ -691,7 +691,7 @@
               },
               "/io": {
                 "type": "page",
-                "title": "🇺🇸 .io",
+                "title": "🇮🇴 .io",
                 "filepath": "content/tld-knowledge-base/cctlds/io.md",
                 "showInSidebar": true
               },
@@ -703,13 +703,13 @@
               },
               "/lc": {
                 "type": "page",
-                "title": "🇺🇸 .lc",
+                "title": "🇱🇨 .lc",
                 "filepath": "content/tld-knowledge-base/cctlds/lc.md",
                 "showInSidebar": true
               },
               "/li": {
                 "type": "page",
-                "title": "🇨🇭 .li",
+                "title": "🇱🇮 .li",
                 "filepath": "content/tld-knowledge-base/cctlds/li.md",
                 "showInSidebar": true
               },
@@ -727,13 +727,13 @@
               },
               "/me": {
                 "type": "page",
-                "title": "🇺🇸 .me",
+                "title": "🇲🇪 .me",
                 "filepath": "content/tld-knowledge-base/cctlds/me.md",
                 "showInSidebar": true
               },
               "/mn": {
                 "type": "page",
-                "title": "🇺🇸 .mn",
+                "title": "🇲🇳 .mn",
                 "filepath": "content/tld-knowledge-base/cctlds/mn.md",
                 "showInSidebar": true
               },
@@ -757,13 +757,13 @@
               },
               "/pr": {
                 "type": "page",
-                "title": "🇺🇸 .pr",
+                "title": "🇵🇷 .pr",
                 "filepath": "content/tld-knowledge-base/cctlds/pr.md",
                 "showInSidebar": true
               },
               "/re": {
                 "type": "page",
-                "title": "🇫🇷 .re",
+                "title": "🇷🇪 .re",
                 "filepath": "content/tld-knowledge-base/cctlds/re.md",
                 "showInSidebar": true
               },
@@ -775,13 +775,13 @@
               },
               "/sc": {
                 "type": "page",
-                "title": "🇺🇸 .sc",
+                "title": "🇸🇨 .sc",
                 "filepath": "content/tld-knowledge-base/cctlds/sc.md",
                 "showInSidebar": true
               },
               "/tf": {
                 "type": "page",
-                "title": "🇫🇷 .tf",
+                "title": "🇹🇫 .tf",
                 "filepath": "content/tld-knowledge-base/cctlds/tf.md",
                 "showInSidebar": true
               },
@@ -789,6 +789,12 @@
                 "type": "page",
                 "title": "🇹🇻 .tv",
                 "filepath": "content/tld-knowledge-base/cctlds/tv.md",
+                "showInSidebar": true
+              },
+              "/ua": {
+                "type": "page",
+                "title": "🇺🇦 .ua",
+                "filepath": "content/tld-knowledge-base/cctlds/ua.md",
                 "showInSidebar": true
               },
               "/uk": {
@@ -805,7 +811,7 @@
               },
               "/vc": {
                 "type": "page",
-                "title": "🇺🇸 .vc",
+                "title": "🇻🇨 .vc",
                 "filepath": "content/tld-knowledge-base/cctlds/vc.md",
                 "showInSidebar": true
               },
@@ -817,13 +823,13 @@
               },
               "/wf": {
                 "type": "page",
-                "title": "🇫🇷 .wf",
+                "title": "🇼🇫 .wf",
                 "filepath": "content/tld-knowledge-base/cctlds/wf.md",
                 "showInSidebar": true
               },
               "/yt": {
                 "type": "page",
-                "title": "🇫🇷 .yt",
+                "title": "🇾🇹 .yt",
                 "filepath": "content/tld-knowledge-base/cctlds/yt.md",
                 "showInSidebar": true
               }

--- a/scripts/tld_knowledge_base/countries.py
+++ b/scripts/tld_knowledge_base/countries.py
@@ -124,6 +124,7 @@ COUNTRY_NAMES: dict[str, str] = {
     "PH": "Philippines",
     "PK": "Pakistan",
     "PL": "Poland",
+    "PM": "Saint Pierre and Miquelon",
     "PR": "Puerto Rico",
     "PT": "Portugal",
     "PW": "Palau",

--- a/scripts/tld_knowledge_base/render.py
+++ b/scripts/tld_knowledge_base/render.py
@@ -66,9 +66,12 @@ def page_title(spec: dict[str, Any]) -> str:
 
 def _country_code(info: TLDInfo) -> str:
     """Best-available ISO-3166-1 alpha-2 country code for a ccTLD."""
+    code = countries.tld_to_country_code(info.name)
+    if code:
+        return code
     if info.registry_country and countries.country_name(info.registry_country):
         return info.registry_country
-    return countries.tld_to_country_code(info.name)
+    return ""
 
 
 def _icon_for(info: TLDInfo) -> str:


### PR DESCRIPTION
Fix country flags displayed in the TLD knowledge base to use the actual TLD country code instead of the registry operator's country... 

For example, `.ag` now shows 🇦🇬 (Antigua and Barbuda) instead of 🇺🇸 (USA - flag from the registry operator).
`.co` shows 🇨🇴 (Colombia) instead of 🇬🇧 (UK), and so on. 

Also adds `.pm` to the ccTLD list - so we get its flag properly displayed.

### Preview

| Before                                                                                                                              	| After                                                                                                                               	|
|-------------------------------------------------------------------------------------------------------------------------------------	|-------------------------------------------------------------------------------------------------------------------------------------	|
| <img width="1303" height="890" alt="image" src="https://github.com/user-attachments/assets/8190aff2-3ed5-4785-a657-7887de5d5351" /> 	| <img width="1319" height="888" alt="image" src="https://github.com/user-attachments/assets/45d436bb-b9e5-4158-87bb-23ce6a26ff15" /> 	|
