### PR TITLE
fix(tld-kb): exclude manually-provisioned TLDs from knowledge base

### DIFF
--- a/scripts/generate_tld_knowledge_base.py
+++ b/scripts/generate_tld_knowledge_base.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Generate the OpusDNS TLD Knowledge Base from compiled TLD specs.
 
-Reads compiled YAML specifications, writes one Markdown page per enabled TLD
-into ``scalar/content/tld-knowledge-base/{cctlds,gtlds}/<tld>.md`` and
-refreshes the sidebar in ``scalar/scalar.config.json``.
+Reads compiled YAML specifications, writes one Markdown page per enabled,
+non-manual TLD into ``scalar/content/tld-knowledge-base/{cctlds,gtlds}/<tld>.md``
+and refreshes the sidebar in ``scalar/scalar.config.json``.
 """
 
 from __future__ import annotations
@@ -23,6 +23,25 @@ from tld_knowledge_base import render, scalar_config  # noqa: E402
 DEFAULT_INPUT = REPO_ROOT.parent / "tld-specifications" / "compiled_specifications"
 DEFAULT_OUTPUT = REPO_ROOT / "scalar" / "content" / "tld-knowledge-base"
 DEFAULT_CONFIG = REPO_ROOT / "scalar" / "scalar.config.json"
+
+# Manually-provisioned TLDs (specifications/ras_manual in OpusDNS/tld-specifications)
+# are enabled in the API but should not be published in the knowledge base.
+MANUAL_PROVISIONING_PROTOCOL = "Custom"
+# Must stay in sync with the provisioning_protocol enum in
+# OpusDNS/tld-specifications specifications/schema.json; an unknown value means
+# this script can no longer tell manual TLDs apart, so it fails fast.
+PROVISIONING_PROTOCOLS = {"EPP", "RRI", "RRP", MANUAL_PROVISIONING_PROTOCOL}
+
+
+def is_manual(config: dict, source: str) -> bool:
+    registry = config.get("registry") or {}
+    protocol = registry.get("provisioning_protocol")
+    if protocol is not None and protocol not in PROVISIONING_PROTOCOLS:
+        raise SystemExit(
+            f"{source}: unknown registry.provisioning_protocol {protocol!r}; "
+            f"expected one of {sorted(PROVISIONING_PROTOCOLS)}"
+        )
+    return protocol == MANUAL_PROVISIONING_PROTOCOL
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -51,6 +70,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Also render TLDs whose tld_configuration.enabled is false",
     )
     parser.add_argument(
+        "--include-manual",
+        action="store_true",
+        help=(
+            "Also render manually-provisioned TLDs "
+            f"(registry provisioning_protocol {MANUAL_PROVISIONING_PROTOCOL!r})"
+        ),
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Render and diff but do not write any files",
@@ -67,11 +94,13 @@ def load_specs(
     input_dir: Path,
     *,
     include_disabled: bool,
+    include_manual: bool,
     allowlist: set[str] | None,
 ) -> list[tuple[Path, dict]]:
     if not input_dir.exists():
         raise SystemExit(f"Input directory does not exist: {input_dir}")
     specs: list[tuple[Path, dict]] = []
+    skipped_manual = 0
     for path in sorted(input_dir.glob("*.yaml")):
         try:
             data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
@@ -81,10 +110,19 @@ def load_specs(
         config = data.get("tld_configuration") or {}
         if not include_disabled and not config.get("enabled"):
             continue
+        if not include_manual and is_manual(config, path.name):
+            skipped_manual += 1
+            continue
         slug = render.page_slug(data)
         if allowlist is not None and slug not in allowlist:
             continue
         specs.append((path, data))
+    if skipped_manual:
+        print(
+            f"skipped {skipped_manual} manually-provisioned spec(s); "
+            "use --include-manual to render them",
+            file=sys.stderr,
+        )
     return specs
 
 
@@ -172,7 +210,12 @@ def prune_stale_pages(
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     allowlist = set(args.tld) if args.tld else None
-    specs = load_specs(args.input, include_disabled=args.include_disabled, allowlist=allowlist)
+    specs = load_specs(
+        args.input,
+        include_disabled=args.include_disabled,
+        include_manual=args.include_manual,
+        allowlist=allowlist,
+    )
     if not specs:
         print("No matching compiled spec files found.", file=sys.stderr)
         return 1

--- a/scripts/test_generate_tld_knowledge_base.py
+++ b/scripts/test_generate_tld_knowledge_base.py
@@ -1,4 +1,4 @@
-"""Unit tests for the notes-merge logic in ``generate_tld_knowledge_base``.
+"""Unit tests for the notes-merge and spec-filtering logic in ``generate_tld_knowledge_base``.
 
 Run from the ``scripts/`` directory (or repo root) with ``python -m pytest``.
 """
@@ -6,8 +6,15 @@ Run from the ``scripts/`` directory (or repo root) with ``python -m pytest``.
 from pathlib import Path
 
 import pytest
+import yaml
 
-from generate_tld_knowledge_base import DEFAULT_NOTES_NAME, NOTES_DIRNAME, load_notes
+from generate_tld_knowledge_base import (
+    DEFAULT_NOTES_NAME,
+    NOTES_DIRNAME,
+    is_manual,
+    load_notes,
+    load_specs,
+)
 
 
 def _write(output_dir: Path, name: str, content: str) -> None:
@@ -53,3 +60,73 @@ def test_append_is_idempotent_against_render_output(tmp_path: Path) -> None:
     merged = page + load_notes(tmp_path, "xyz")
     assert merged == "# Title\n\n## Section\n\nrow\n\n## Notes\n\nbody\n"
     assert merged == page + load_notes(tmp_path, "xyz")
+
+
+def _write_spec(
+    input_dir: Path,
+    name: str,
+    *,
+    enabled: bool = True,
+    provisioning_protocol: str = "EPP",
+) -> None:
+    spec = {
+        "tld_configuration": {
+            "enabled": enabled,
+            "tlds": [{"name": name, "type": "gTLD"}],
+            "registry": {
+                "name": "Example Registry",
+                "provisioning_protocol": provisioning_protocol,
+            },
+        }
+    }
+    (input_dir / f"{name}.yaml").write_text(yaml.safe_dump(spec), encoding="utf-8")
+
+
+def _loaded_slugs(input_dir: Path, **kwargs: bool) -> set[str]:
+    kwargs.setdefault("include_disabled", False)
+    kwargs.setdefault("include_manual", False)
+    specs = load_specs(input_dir, allowlist=None, **kwargs)
+    return {data["tld_configuration"]["tlds"][0]["name"] for _path, data in specs}
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected"),
+    [
+        ({}, {"epp"}),
+        ({"include_manual": True}, {"epp", "manual"}),
+        ({"include_disabled": True}, {"epp", "disabled"}),
+        ({"include_disabled": True, "include_manual": True}, {"epp", "disabled", "manual"}),
+    ],
+)
+def test_load_specs_excludes_manual_and_disabled_tlds(
+    tmp_path: Path, kwargs: dict[str, bool], expected: set[str]
+) -> None:
+    _write_spec(tmp_path, "epp")
+    _write_spec(tmp_path, "manual", provisioning_protocol="Custom")
+    _write_spec(tmp_path, "disabled", enabled=False)
+    assert _loaded_slugs(tmp_path, **kwargs) == expected
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {},
+        {"registry": None},
+        {"registry": {}},
+        {"registry": {"provisioning_protocol": None}},
+        {"registry": {"provisioning_protocol": "EPP"}},
+        {"registry": {"provisioning_protocol": "RRI"}},
+    ],
+)
+def test_is_manual_treats_missing_or_known_protocols_as_not_manual(config: dict) -> None:
+    assert not is_manual(config, "x.yaml")
+
+
+def test_is_manual_detects_manual_protocol() -> None:
+    assert is_manual({"registry": {"provisioning_protocol": "Custom"}}, "x.yaml")
+
+
+@pytest.mark.parametrize("protocol", ["custom", "MANUAL", "API"])
+def test_is_manual_fails_fast_on_unknown_protocol(protocol: str) -> None:
+    with pytest.raises(SystemExit, match="unknown registry.provisioning_protocol"):
+        is_manual({"registry": {"provisioning_protocol": protocol}}, "x.yaml")


### PR DESCRIPTION
Skip TLDs with `registry.provisioning_protocol: Custom` (the 23 `ras_manual` TLDs) when generating the TLD knowledge base, so they no longer appear in the developer docs. `--include-manual` opts back in, mirroring `--include-disabled`.

- Fails fast on a provisioning protocol outside the tld-specifications schema enum (`EPP`/`RRI`/`RRP`/`Custom`) so upstream renames can't silently re-publish manual TLDs.
- Logs a skip summary to stderr so the exclusion is visible in CI runs.

Merging this triggers the **Generate TLD Knowledge Base** workflow (it watches the generator path on main), which will open the bot PR removing the 23 existing pages and their sidebar entries. Verified by dry run against current compiled specs: exactly bar, bayern, berlin, blog, click, cloud, cologne, dk, earth, faith, hamburg, help, koeln, love, lt, nrw, one, pl, ruhr, saarland, sexy, tel, trade are pruned.