### PR TITLE
feat(tld-kb): exclude TLDs from the knowledge base via an exclude file

### DIFF
--- a/scripts/generate_tld_knowledge_base.py
+++ b/scripts/generate_tld_knowledge_base.py
@@ -23,6 +23,7 @@ from tld_knowledge_base import render, scalar_config  # noqa: E402
 DEFAULT_INPUT = REPO_ROOT.parent / "tld-specifications" / "compiled_specifications"
 DEFAULT_OUTPUT = REPO_ROOT / "scalar" / "content" / "tld-knowledge-base"
 DEFAULT_CONFIG = REPO_ROOT / "scalar" / "scalar.config.json"
+DEFAULT_EXCLUDE_FILE = REPO_ROOT / "scripts" / "tld_knowledge_base" / "excluded_tlds.txt"
 
 # Manually-provisioned TLDs (specifications/ras_manual in OpusDNS/tld-specifications)
 # are enabled in the API but should not be published in the knowledge base.
@@ -78,6 +79,17 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--exclude-file",
+        type=Path,
+        default=DEFAULT_EXCLUDE_FILE,
+        help="File listing TLD spec names to exclude from the knowledge base (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--include-excluded",
+        action="store_true",
+        help="Also render TLDs listed in the exclude file",
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Render and diff but do not write any files",
@@ -88,6 +100,44 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Limit generation to specific TLD(s); may be repeated",
     )
     return parser.parse_args(argv)
+
+
+def load_excluded(path: Path) -> set[str]:
+    """TLD names to keep out of the knowledge base, read from ``path``.
+
+    One TLD name per line (e.g. ``si``, ``cn.com``); a trailing ``.yaml`` is
+    tolerated. Anything after ``#`` is a comment. A missing file means nothing
+    is excluded.
+    """
+    if not path.exists():
+        return set()
+    names: set[str] = set()
+    for line in path.read_text(encoding="utf-8").splitlines():
+        entry = line.split("#", 1)[0].strip()
+        if entry:
+            names.add(entry.removesuffix(".yaml"))
+    return names
+
+
+def tld_name(spec: dict) -> str:
+    tlds = (spec.get("tld_configuration") or {}).get("tlds") or []
+    return tlds[0].get("name", "") if tlds else ""
+
+
+def apply_exclusions(
+    specs: list[tuple[Path, dict]],
+    excluded: set[str],
+) -> list[tuple[Path, dict]]:
+    if not excluded:
+        return specs
+    present = {tld_name(spec) for _path, spec in specs}
+    for missing in sorted(excluded - present):
+        print(
+            f"::warning::excluded TLD '{missing}' matches no spec; "
+            "remove it from the exclude file or fix the name",
+            file=sys.stderr,
+        )
+    return [(path, spec) for path, spec in specs if tld_name(spec) not in excluded]
 
 
 def load_specs(
@@ -216,6 +266,8 @@ def main(argv: list[str] | None = None) -> int:
         include_manual=args.include_manual,
         allowlist=allowlist,
     )
+    if not args.include_excluded:
+        specs = apply_exclusions(specs, load_excluded(args.exclude_file))
     if not specs:
         print("No matching compiled spec files found.", file=sys.stderr)
         return 1

--- a/scripts/test_generate_tld_knowledge_base.py
+++ b/scripts/test_generate_tld_knowledge_base.py
@@ -70,7 +70,15 @@ def test_load_excluded_missing_file_is_empty(tmp_path: Path) -> None:
 def test_load_excluded_strips_comments_blanks_and_yaml_suffix(tmp_path: Path) -> None:
     target = tmp_path / "excluded_tlds.txt"
     target.write_text(
-        "# header\nsi\nit  # in OTE\n\ncn.com.yaml\n  lu  \n",
+        "\n".join([
+            "# header",
+            "si",
+            "it  # in OTE",
+            "",
+            "cn.com.yaml",
+            "  lu  ",
+            "",
+        ]),
         encoding="utf-8",
     )
     assert load_excluded(target) == {"si", "it", "cn.com", "lu"}

--- a/scripts/test_generate_tld_knowledge_base.py
+++ b/scripts/test_generate_tld_knowledge_base.py
@@ -12,6 +12,7 @@ from generate_tld_knowledge_base import (
     DEFAULT_NOTES_NAME,
     NOTES_DIRNAME,
     is_manual,
+    load_excluded,
     load_notes,
     load_specs,
 )
@@ -60,6 +61,19 @@ def test_append_is_idempotent_against_render_output(tmp_path: Path) -> None:
     merged = page + load_notes(tmp_path, "xyz")
     assert merged == "# Title\n\n## Section\n\nrow\n\n## Notes\n\nbody\n"
     assert merged == page + load_notes(tmp_path, "xyz")
+
+
+def test_load_excluded_missing_file_is_empty(tmp_path: Path) -> None:
+    assert load_excluded(tmp_path / "nope.txt") == set()
+
+
+def test_load_excluded_strips_comments_blanks_and_yaml_suffix(tmp_path: Path) -> None:
+    target = tmp_path / "excluded_tlds.txt"
+    target.write_text(
+        "# header\nsi\nit  # in OTE\n\ncn.com.yaml\n  lu  \n",
+        encoding="utf-8",
+    )
+    assert load_excluded(target) == {"si", "it", "cn.com", "lu"}
 
 
 def _write_spec(

--- a/scripts/tld_knowledge_base/excluded_tlds.txt
+++ b/scripts/tld_knowledge_base/excluded_tlds.txt
@@ -6,4 +6,6 @@ si # no pricing yet
 it # WIP
 lu # WIP
 lt # WIP
+ua # WIP
 cloud # no pricing yet
+name # doesn't fully work, some domain:check cmds fail

--- a/scripts/tld_knowledge_base/excluded_tlds.txt
+++ b/scripts/tld_knowledge_base/excluded_tlds.txt
@@ -1,0 +1,9 @@
+# TLDs that are excluded from the public TLD Knowledge Base.
+# One TLD name per line (e.g. "si" or "cn.com"). Anything after # is a comment.
+# Remove a line to publish that TLD again.
+# Excluded TLDs stay fully usable at runtime; this only hides the docs page.
+si # no pricing yet
+it # WIP
+lu # WIP
+lt # WIP
+cloud # no pricing yet


### PR DESCRIPTION
Adds a file-based exclusion for the TLD knowledge base, complementing the existing manual-provisioning filter:
- #41

This time, to exclude TLDs that are `enabled` but that we still don't want to document - so basically "unpublished" TLDs.

TLDs listed in `scripts/tld_knowledge_base/excluded_tlds.txt` are skipped when generating the KB. 
They stay fully usable at runtime - this only hides their docs page. 

Currently excluded TLDs: 
- `.si` - no pricing yet
- `.it` - WIP
- `.lu` - WIP
- `.lt` - WIP
- `.ua` - WIP
- `.cloud` - no pricing yet
- `.name` - doesn't fully work, some `domain:check` cmds fail

## Usage
- Add/remove a TLD name (one per line, `#` for comments) in `excluded_tlds.txt`.
- `--exclude-file PATH` to use a different list.
- `--include-excluded` to render them anyway.

A name that matches no spec logs a warning so stale entries get caught.