### PR TITLE
docs: document role-based permissions system

### DIFF
--- a/scalar/content/account/organizations.md
+++ b/scalar/content/account/organizations.md
@@ -87,15 +87,10 @@ request. You can also create users later via the
 
 ## Roles
 
-Roles determine what permissions users have within an organization. List the
-available roles:
-
-```bash
-curl "$OPUSDNS_API_BASE/v1/organizations/roles" \
-  --header "X-Api-Key: $OPUSDNS_API_KEY"
-```
-
-See [User management](/account/users) for how to assign roles to users.
+Roles determine what permissions users and API keys have within an organization
+— through built-in roles or your own custom roles. See
+[Roles & permissions](/account/organizations/roles) for the full guide, and
+[User management](/account/users) for how to assign a role to a user.
 
 ## Related API Reference
 

--- a/scalar/content/account/roles.md
+++ b/scalar/content/account/roles.md
@@ -1,0 +1,220 @@
+# Roles & permissions
+
+Roles control what each user and API key can do inside an organization. A role
+is a named bundle of **permissions**, and every permission grants a single
+**scope** on a single **resource**. OpusDNS ships a set of **built-in roles**
+that cover the most common needs, and you can define your own **custom roles**
+when you need a more specific set of permissions.
+
+Roles are scoped to an organization. A user or API key in a suborganization can
+only ever hold a role defined in — and limited to — that suborganization.
+
+## Permissions
+
+A permission is written as a `resource:scope` string, for example
+`domains:read` or `dns:manage`. The scope describes what level of access the
+permission grants:
+
+| Scope | Grants |
+| --- | --- |
+| `read` | View resources of this type (list and get). |
+| `manage` | Create and update resources of this type. |
+| `delete` | Delete resources of this type. |
+
+Permissions exist for each resource area of the API:
+
+`organization`, `domains`, `contacts`, `dns`, `hosts`, `email_forwards`,
+`domain_forwards`, `parking`, `events`, `jobs`, `billing`, `users`, `api_keys`,
+`registrar_credentials`, `tags`, `audit_logs`
+
+To retrieve the exact catalog of permissions a custom role may grant, call:
+
+```bash
+curl "$OPUSDNS_API_BASE/v1/organizations/role-permissions" \
+  --header "X-Api-Key: $OPUSDNS_API_KEY"
+```
+
+```json
+{
+  "permissions": [
+    "audit_logs:read",
+    "billing:manage",
+    "billing:read",
+    "contacts:delete",
+    "contacts:manage",
+    "contacts:read",
+    "dns:delete",
+    "dns:manage",
+    "dns:read",
+    "domains:delete",
+    "domains:manage",
+    "domains:read"
+  ]
+}
+```
+
+## Built-in roles
+
+Built-in roles are maintained by OpusDNS and are available in every
+organization. They are immutable — you cannot change or delete them.
+
+| Role | What it grants |
+| --- | --- |
+| `owner` | Full access. The organization's first user / super-admin. Report-only — see below. |
+| `admin` | Full access to every resource in the organization. |
+| `viewer` | Read-only access across domains, DNS, contacts, hosts, forwarding, parking, events, jobs, and users. |
+| `domain_manager` | Full access (read/manage/delete) to domains, DNS, contacts, hosts, email & domain forwarding, parking, events, and jobs. |
+| `dns_manager` | Full access to DNS zones, email forwarding, and domain forwarding. |
+| `billing_manager` | Read and manage billing. |
+
+<scalar-callout type="info">
+`owner` is **report-only**. It identifies the organization's first user and is never assigned through the role API — it is established when the organization is created. The remaining built-in roles are freely assignable.
+</scalar-callout>
+
+## Custom roles
+
+When the built-in roles don't fit, create a custom role with exactly the
+permissions you need. Custom roles are owned by your organization.
+
+Each custom role has a **label** — a `snake_case` identifier derived from its
+display name (for example, the name `Support Staff` produces the label
+`support_staff`). The label is unique within the organization and is used as the
+URL path parameter for the role.
+
+<scalar-callout type="info">
+Custom roles cannot grant the escalation-bearing `admin` or `owner` permissions. Use the built-in `admin` role when full access is required.
+</scalar-callout>
+
+### Listing roles
+
+List every role assignable in the organization — the built-in roles plus your
+custom roles:
+
+```bash
+curl "$OPUSDNS_API_BASE/v1/organizations/roles" \
+  --header "X-Api-Key: $OPUSDNS_API_KEY"
+```
+
+```json
+[
+  {
+    "label": "admin",
+    "name": "Admin",
+    "description": "Full access to the organization.",
+    "built_in": true,
+    "permissions": ["organization:manage", "domains:manage", "dns:manage"]
+  },
+  {
+    "label": "support_staff",
+    "name": "Support Staff",
+    "description": "Read domains and manage DNS.",
+    "built_in": false,
+    "permissions": ["domains:read", "dns:manage"],
+    "created_on": "2026-06-16T10:00:00Z",
+    "updated_on": "2026-06-16T10:00:00Z"
+  }
+]
+```
+
+### Creating a custom role
+
+```bash
+curl "$OPUSDNS_API_BASE/v1/organizations/roles" \
+  --request POST \
+  --header "X-Api-Key: $OPUSDNS_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "name": "Support Staff",
+    "description": "Read domains and manage DNS.",
+    "permissions": ["domains:read", "dns:manage"]
+  }'
+```
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `name` | Yes | Display name (1–64 chars). The label is derived from this. |
+| `description` | No | Free-text description of the role. |
+| `permissions` | Yes | List of `resource:scope` strings the role grants. |
+
+The response is the created role, including its generated `label`:
+
+```json
+{
+  "label": "support_staff",
+  "name": "Support Staff",
+  "description": "Read domains and manage DNS.",
+  "built_in": false,
+  "permissions": ["dns:manage", "domains:read"],
+  "created_on": "2026-06-16T10:00:00Z",
+  "updated_on": "2026-06-16T10:00:00Z"
+}
+```
+
+A name that resolves to a built-in role label, or a duplicate name within the
+organization, returns `409 Conflict`.
+
+### Getting a single role
+
+Retrieve any role — built-in or custom — by its label:
+
+```bash
+curl "$OPUSDNS_API_BASE/v1/organizations/roles/support_staff" \
+  --header "X-Api-Key: $OPUSDNS_API_KEY"
+```
+
+### Updating a custom role
+
+Update a custom role's name, description, and/or permissions. Provide only the
+fields you want to change. When `permissions` is included it is a **full
+replacement** of the role's permission set.
+
+```bash
+curl "$OPUSDNS_API_BASE/v1/organizations/roles/support_staff" \
+  --request PATCH \
+  --header "X-Api-Key: $OPUSDNS_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "permissions": ["domains:read", "dns:manage", "dns:delete"]
+  }'
+```
+
+<scalar-callout type="info">
+Permission changes take effect immediately for every user and API key that holds the role. Built-in roles are immutable and return `409 Conflict` if you attempt to update them.
+</scalar-callout>
+
+### Deleting a custom role
+
+```bash
+curl "$OPUSDNS_API_BASE/v1/organizations/roles/support_staff" \
+  --request DELETE \
+  --header "X-Api-Key: $OPUSDNS_API_KEY"
+```
+
+<scalar-callout type="warning">
+A role cannot be deleted while it is still assigned to any user or API key — reassign those subjects first, or the request returns `409 Conflict`. Built-in roles cannot be deleted.
+</scalar-callout>
+
+## Assigning roles
+
+Roles are granted per subject:
+
+- **Users** — assign a role with the
+  [User management](/account/users) role endpoints.
+- **API keys** — every API key carries its own role, granted when the key is
+  issued (defaulting to `admin`, full access). A key's role governs its
+  permissions exactly like a user's role, and applies independently of the user
+  who created the key. Choose or change a key's role from the **API Credentials**
+  page of the [OpusDNS Dashboard](https://app.opusdns.com/developer/api-credentials).
+  Grant each key the narrowest role it needs.
+
+You can assign either a built-in role (by name, for example `viewer`) or a
+custom role (by its label, for example `support_staff`).
+
+## Related API Reference
+
+- [`GET /v1/organizations/roles`](/api-reference#tag/organization/GET/v1/organizations/roles)
+- [`POST /v1/organizations/roles`](/api-reference#tag/organization/POST/v1/organizations/roles)
+- [`GET /v1/organizations/role-permissions`](/api-reference#tag/organization/GET/v1/organizations/role-permissions)
+- [`GET /v1/organizations/roles/{label}`](/api-reference#tag/organization/GET/v1/organizations/roles/{label})
+- [`PATCH /v1/organizations/roles/{label}`](/api-reference#tag/organization/PATCH/v1/organizations/roles/{label})
+- [`DELETE /v1/organizations/roles/{label}`](/api-reference#tag/organization/DELETE/v1/organizations/roles/{label})

--- a/scalar/content/account/user-management.md
+++ b/scalar/content/account/user-management.md
@@ -115,6 +115,45 @@ curl "$OPUSDNS_API_BASE/v1/users/user_01h45ytscbebyvny4gc8cr8ma2" \
 
 Only include the fields you want to change.
 
+## Roles
+
+Each user holds a single role that determines what they can do within the
+organization. See [Roles & permissions](/account/organizations/roles) for how
+roles and permissions work, and the list of built-in roles.
+
+### Getting a user's role
+
+```bash
+curl "$OPUSDNS_API_BASE/v1/users/user_01h45ytscbebyvny4gc8cr8ma2/role" \
+  --header "X-Api-Key: $OPUSDNS_API_KEY"
+```
+
+```json
+{
+  "role": "domain_manager"
+}
+```
+
+### Setting a user's role
+
+Assign a role with a `PUT` request, replacing any existing role. Pass either a
+built-in role name (for example `viewer`) or the label of a custom role owned by
+the user's organization (for example `support_staff`):
+
+```bash
+curl "$OPUSDNS_API_BASE/v1/users/user_01h45ytscbebyvny4gc8cr8ma2/role" \
+  --request PUT \
+  --header "X-Api-Key: $OPUSDNS_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "role": "support_staff"
+  }'
+```
+
+<scalar-callout type="info">
+The `owner` role cannot be assigned through this endpoint — it is report-only and established when the organization is created. Sending `owner` returns a validation error.
+</scalar-callout>
+
 ## Deleting a user
 
 Remove a user from the organization:
@@ -136,3 +175,5 @@ You cannot delete yourself or the last admin user in an organization. These oper
 - [`GET /v1/users/{user_id}`](/api-reference#tag/user/GET/v1/users/{user_id})
 - [`PATCH /v1/users/{user_id}`](/api-reference#tag/user/PATCH/v1/users/{user_id})
 - [`DELETE /v1/users/{user_id}`](/api-reference#tag/user/DELETE/v1/users/{user_id})
+- [`GET /v1/users/{user_id}/role`](/api-reference#tag/user/GET/v1/users/{user_id}/role)
+- [`PUT /v1/users/{user_id}/role`](/api-reference#tag/user/PUT/v1/users/{user_id}/role)

--- a/scalar/content/authentication.md
+++ b/scalar/content/authentication.md
@@ -28,12 +28,21 @@ curl "$OPUSDNS_API_BASE/v1/domains" \
    [API Credentials](https://app.opusdns.com/developer/api-credentials).
 2. Click **Create API Credential**.
 3. Give the credential a name and description, then choose an expiration date.
+4. Select the **role** that governs what the key can do — a built-in role (such
+   as `admin` or `viewer`) or one of your organization's custom roles. The role
+   defaults to `admin` (full access). See
+   [Roles & permissions](/account/organizations/roles) for what each role
+   grants.
 
 ![Create API credential dialog](/images/auth-create-api-credential.png)
 
 After creation, copy the **client ID**, **API key**, and **client secret**
 immediately. The API key and client secret are only displayed once — they
 cannot be retrieved later.
+
+<scalar-callout type="info">
+An API key carries its own role, independently of the user who created it. Grant each key the narrowest role it needs — for example, a deployment script that only edits DNS can use a key with the `dns_manager` role instead of `admin`.
+</scalar-callout>
 
 <img src="/images/auth-api-credential-created.png" alt="API credential created dialog" width="500" />
 

--- a/scalar/content/changelog.md
+++ b/scalar/content/changelog.md
@@ -4,6 +4,22 @@ Track notable updates to the OpusDNS API and developer documentation here.
 
 ## 2026
 
+### 16 June 2026
+
+- Released the **role-based permissions** system. Access is now governed by
+  roles built from `resource:scope` permissions (scopes: `read`, `manage`,
+  `delete`).
+- Added **built-in roles** — `admin`, `viewer`, `domain_manager`, `dns_manager`,
+  and `billing_manager` — available in every organization.
+- Added **custom roles** — define organization-owned roles with exactly the
+  permissions you need via `POST /v1/organizations/roles`, and manage them with
+  `GET`/`PATCH`/`DELETE /v1/organizations/roles/{label}`. Retrieve the grantable
+  permission catalog from `GET /v1/organizations/role-permissions`.
+- Added **per-user role assignment** — `GET` and `PUT /v1/users/{user_id}/role`
+  set a user's built-in or custom role. API keys are granted a role at issuance.
+- Published the [Roles & permissions](/account/organizations/roles) guide and a
+  roles section in [User management](/account/users).
+
 ### 12 June 2026
 
 - Added **host object management** — create, retrieve, update, and delete
@@ -13,8 +29,6 @@ Track notable updates to the OpusDNS API and developer documentation here.
   ID or hostname.
 - Published the [Host objects (glue records)](/products/domains/host-objects)
   guide and linked it from the nameservers, registration, and transfer guides.
-
-### 14 May 2026
 
 - Added **batch retry** — re-attempt jobs in a batch that ended in `failed` or
   `dead_letter` state without rebuilding the batch.

--- a/scalar/scalar.config.json
+++ b/scalar/scalar.config.json
@@ -177,6 +177,13 @@
                     "filepath": "content/account/organizations.md",
                     "showInSidebar": true
                   },
+                  "/roles": {
+                    "type": "page",
+                    "title": "Roles & permissions",
+                    "icon": "phosphor/regular/shield-check",
+                    "filepath": "content/account/roles.md",
+                    "showInSidebar": true
+                  },
                   "/manage": {
                     "type": "page",
                     "title": "Manage suborganizations",


### PR DESCRIPTION
### Description

Documents the new role-based permissions system in the developer docs (Scalar). Previously the docs had only a 4-line "Roles" stub under Organizations and no role content elsewhere.

### Changes

- **New page** `content/account/roles.md` — "Roles & permissions" (Organizations group):
  - `resource:scope` permission model; scopes `read` / `manage` / `delete` + full resource list
  - Grantable permission catalog (`GET /v1/organizations/role-permissions`)
  - Built-in roles table (`owner` report-only; `admin`, `viewer`, `domain_manager`, `dns_manager`, `billing_manager`) and what each grants
  - Custom-role CRUD: `GET`/`POST /v1/organizations/roles`, `GET`/`PATCH`/`DELETE /roles/{label}` — label semantics, immutability + in-use guards
- **User management** (`user-management.md`) — new "Roles" section: `GET`/`PUT /v1/users/{user_id}/role`, built-in vs custom labels, owner report-only; added api-reference links
- **Authentication** (`authentication.md`) — "Creating an API key" now includes a role-selection step (built-in or custom, defaults to `admin`) + least-privilege callout
- **Organizations** (`organizations.md`) — replaced the Roles stub with a link to the new page
- **Sidebar** (`scalar.config.json`) — wired `/roles` into the Organizations group (`shield-check` icon)
- **Changelog** — added a `16 June 2026` entry

### Testing

```bash
cd scalar && npm run check   # scalar project check-config -> [SUCCESS]
```

All cross-page links and api-reference anchors verified consistent.

### Notes

API-key (`client_credentials`) endpoints are excluded from the public OpenAPI schema, so API-key role management is documented as a Dashboard flow (no api-reference deep link).

### Checklist

- [x] I have written unit tests for new code where applicable. _(N/A — docs only)_
- [x] I have added comments and documentation where necessary.
- [x] I have manually tested this PR on my local machine. _(ran `npm run check`)_
