### PR TITLE
Cache compiled IDN tables

### DIFF
--- a/.github/workflows/tld-knowledge-base.yaml
+++ b/.github/workflows/tld-knowledge-base.yaml
@@ -60,6 +60,15 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      # Cache compiled IDN tables to avoid re-downloading ~1900 from IANA each run.
+      - name: Cache compiled IDN tables
+        uses: actions/cache@v4
+        with:
+          path: tld-specifications/idn_tables
+          key: idn-tables-${{ hashFiles('tld-specifications/specifications/**/*.yaml') }}
+          restore-keys: |
+            idn-tables-
+
       - name: Compile TLD specifications
         working-directory: tld-specifications
         run: |


### PR DESCRIPTION
Caches the compiled IDN tables (`tld-specifications/idn_tables/`) across workflow runs.

The `tld-specifications` repo is checked out fresh each run and doesn't commit `idn_tables/`, so every run re-downloaded ~1900 IDN tables from IANA..

**How it works:**
- `actions/cache`:
  - restores `idn_tables/` to disk before the compile step. 
  - the compiler already skips any table whose output file exists (`output_path.exists()`), so a restored cache means ~0 downloads - unless we're adding them, etc.
  - `key` is hashed over the specs, so it changes whenever specs change - this is what triggers a re-save and lets newly added tables get persisted.
- `restore-keys: idn-tables-` fallback: 
  - on a key miss (the common case, since specs change often) it restores the most recent previous cache
  - so we only download tables that are genuinely new

**Effect:** 
first run after merge is still cold (downloads + saves the cache); subsequent runs restore it and skip the downloads. 
Old cache entries are evicted automatically by GitHub (7 days unused), so nothing to clean up.
