### PR TITLE
docs: fix transaction id prefix in billing curl example

### DIFF
--- a/scalar/content/account/billing.md
+++ b/scalar/content/account/billing.md
@@ -34,7 +34,7 @@ curl "$OPUSDNS_API_BASE/v1/organizations/organization_01h45ytscbebyvny4gc8cr8ma2
 Get full details for a specific transaction:
 
 ```bash
-curl "$OPUSDNS_API_BASE/v1/organizations/organization_01h45ytscbebyvny4gc8cr8ma2/transactions/transaction_01h45ytscbebyvny4gc8cr8ma2" \
+curl "$OPUSDNS_API_BASE/v1/organizations/organization_01h45ytscbebyvny4gc8cr8ma2/transactions/billing_transaction_01h45ytscbebyvny4gc8cr8ma2" \
   --header "X-Api-Key: $OPUSDNS_API_KEY"
 ```
 


### PR DESCRIPTION
Customer-reported doc bug (HubSpot #419323994328).

The `Transaction detail` curl example used `transaction_01h45...` for the path id. Billing transaction ids use the `billing_transaction_` prefix (`BillingTransactionId.expected_prefix()`), so the example wouldn't work as written.

The `{transaction_id}` path-parameter name in the Related API Reference link is left unchanged — it matches the actual API route and OpenAPI anchor; only the example value was wrong.