### PR TITLE
docs: add volume/unit to BillingTransactionResponse spec

### DIFF
--- a/src/helpers/keys.ts
+++ b/src/helpers/keys.ts
@@ -399,7 +399,9 @@ export const KEY_BILLING_TRANSACTION_PRODUCT_TYPE = 'product_type' satisfies key
 export const KEY_BILLING_TRANSACTION_STATUS = 'status' satisfies keyof BillingTransaction;
 export const KEY_BILLING_TRANSACTION_TAX_AMOUNT = 'tax_amount' satisfies keyof BillingTransaction;
 export const KEY_BILLING_TRANSACTION_TAX_RATE = 'tax_rate' satisfies keyof BillingTransaction;
+export const KEY_BILLING_TRANSACTION_UNIT = 'unit' satisfies keyof BillingTransaction;
 export const KEY_BILLING_TRANSACTION_UPDATED_ON = 'updated_on' satisfies keyof BillingTransaction;
+export const KEY_BILLING_TRANSACTION_VOLUME = 'volume' satisfies keyof BillingTransaction;
 
 export const KEYS_BILLING_TRANSACTION = [
   KEY_BILLING_TRANSACTION_ACTION,
@@ -414,7 +416,9 @@ export const KEYS_BILLING_TRANSACTION = [
   KEY_BILLING_TRANSACTION_STATUS,
   KEY_BILLING_TRANSACTION_TAX_AMOUNT,
   KEY_BILLING_TRANSACTION_TAX_RATE,
+  KEY_BILLING_TRANSACTION_UNIT,
   KEY_BILLING_TRANSACTION_UPDATED_ON,
+  KEY_BILLING_TRANSACTION_VOLUME,
 ] as const satisfies (keyof BillingTransaction)[];
 
 export const KEY_BROWSER_STATS_BUCKET_KEY = 'key' satisfies keyof BrowserStatsBucket;

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -221,15 +221,31 @@ components:
           pattern: ^(?!^[-+.]*$)[+-]?0*(?:\d{0,8}|(?=[\d.]{1,11}0*$)\d{0,8}\.\d{0,2}0*$)
           title: Tax Rate
           type: string
+        unit:
+          anyOf:
+          - maxLength: 255
+            minLength: 1
+            type: string
+          - type: 'null'
+          description: The unit for `volume` (e.g. 'y' for years when renewing a domain);
+            null when not applicable
+          title: Unit
         updated_on:
           description: The date/time the transaction was updated
           format: date-time
           title: Updated On
           type: string
+        volume:
+          description: The quantity the transaction covers, expressed in `unit` (e.g.
+            1 for a one-year domain renewal)
+          pattern: ^(?!^[-+.]*$)[+-]?0*(?:\d{0,8}|(?=[\d.]{1,11}0*$)\d{0,8}\.\d{0,2}0*$)
+          title: Volume
+          type: string
       required:
       - product_type
       - product_reference
       - action
+      - volume
       - amount
       - price
       - tax_rate

--- a/src/schema.d.ts
+++ b/src/schema.d.ts
@@ -2728,11 +2728,21 @@ export interface components {
              */
             tax_rate: string;
             /**
+             * Unit
+             * @description The unit for `volume` (e.g. 'y' for years when renewing a domain); null when not applicable
+             */
+            unit?: string | null;
+            /**
              * Updated On
              * Format: date-time
              * @description The date/time the transaction was updated
              */
             updated_on?: Date;
+            /**
+             * Volume
+             * @description The quantity the transaction covers, expressed in `unit` (e.g. 1 for a one-year domain renewal)
+             */
+            volume: string;
         };
         /**
          * BillingTransactionSortField


### PR DESCRIPTION
Surfaces the renewal quantity fields added in [opusdns-api#4611](https://github.com/OpusDNS/opusdns-api/pull/4611) in the public API reference. Customer-reported gap (HubSpot #419323994328).

`BillingTransactionResponse` now documents:
- `volume` (required) — quantity the transaction covers
- `unit` (nullable) — unit for `volume` (e.g. `y` for a one-year domain renewal)

Property defs taken verbatim from the app's generated spec (`dev-resources/openapi/generate_openapi_spec.py`); `src/schema.d.ts` and `src/helpers/keys.ts` regenerated via `npm run generate:schema && generate:helpers`. Live in production on `api-organization-0.12.21`.