### PR TITLE
fix(tld-kb): add Bahrain (BH) country code, fix .bh flags

### DIFF
--- a/scalar/content/tld-knowledge-base/cctlds/bh.md
+++ b/scalar/content/tld-knowledge-base/cctlds/bh.md
@@ -1,4 +1,4 @@
-# 🌐 .bh
+# 🇧🇭 .bh — Bahrain
 
 > The **.bh** is a country-code top-level domain (ccTLD) operated by Telecommunications Regulatory Authority (TRA). This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
 
@@ -8,7 +8,7 @@
 | --- | --- |
 | TLD Type | ccTLD |
 | Registry | Telecommunications Regulatory Authority (TRA) |
-| Registry Country | BH |
+| Registry Country | Bahrain |
 | Registry Website | [domains.bh](https://domains.bh/) |
 | Provisioning Protocol | EPP |
 | Second-Level Registration | ✅ Yes |

--- a/scalar/content/tld-knowledge-base/cctlds/biz.bh.md
+++ b/scalar/content/tld-knowledge-base/cctlds/biz.bh.md
@@ -1,4 +1,4 @@
-# 🇬🇧 .biz.bh — United Kingdom
+# 🇧🇭 .biz.bh — Bahrain
 
 > The **.biz.bh** is a country-code top-level domain (ccTLD) operated by CentralNic Group PLC. This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
 

--- a/scalar/content/tld-knowledge-base/cctlds/cc.bh.md
+++ b/scalar/content/tld-knowledge-base/cctlds/cc.bh.md
@@ -1,4 +1,4 @@
-# 🇨🇨 .cc.bh — Cocos (Keeling) Islands
+# 🇧🇭 .cc.bh — Bahrain
 
 > The **.cc.bh** is a country-code top-level domain (ccTLD) operated by CentralNic Group PLC. This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
 

--- a/scalar/content/tld-knowledge-base/cctlds/com.bh.md
+++ b/scalar/content/tld-knowledge-base/cctlds/com.bh.md
@@ -1,4 +1,4 @@
-# 🇬🇧 .com.bh — United Kingdom
+# 🇧🇭 .com.bh — Bahrain
 
 > The **.com.bh** is a country-code top-level domain (ccTLD) operated by CentralNic Group PLC. This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
 

--- a/scalar/content/tld-knowledge-base/cctlds/edu.bh.md
+++ b/scalar/content/tld-knowledge-base/cctlds/edu.bh.md
@@ -1,4 +1,4 @@
-# 🇬🇧 .edu.bh — United Kingdom
+# 🇧🇭 .edu.bh — Bahrain
 
 > The **.edu.bh** is a country-code top-level domain (ccTLD) operated by CentralNic Group PLC. This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
 

--- a/scalar/content/tld-knowledge-base/cctlds/info.bh.md
+++ b/scalar/content/tld-knowledge-base/cctlds/info.bh.md
@@ -1,4 +1,4 @@
-# 🇬🇧 .info.bh — United Kingdom
+# 🇧🇭 .info.bh — Bahrain
 
 > The **.info.bh** is a country-code top-level domain (ccTLD) operated by CentralNic Group PLC. This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
 

--- a/scalar/content/tld-knowledge-base/cctlds/me.bh.md
+++ b/scalar/content/tld-knowledge-base/cctlds/me.bh.md
@@ -1,4 +1,4 @@
-# 🇲🇪 .me.bh — Montenegro
+# 🇧🇭 .me.bh — Bahrain
 
 > The **.me.bh** is a country-code top-level domain (ccTLD) operated by CentralNic Group PLC. This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
 

--- a/scalar/content/tld-knowledge-base/cctlds/name.bh.md
+++ b/scalar/content/tld-knowledge-base/cctlds/name.bh.md
@@ -1,4 +1,4 @@
-# 🇬🇧 .name.bh — United Kingdom
+# 🇧🇭 .name.bh — Bahrain
 
 > The **.name.bh** is a country-code top-level domain (ccTLD) operated by CentralNic Group PLC. This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
 

--- a/scalar/content/tld-knowledge-base/cctlds/net.bh.md
+++ b/scalar/content/tld-knowledge-base/cctlds/net.bh.md
@@ -1,4 +1,4 @@
-# 🇬🇧 .net.bh — United Kingdom
+# 🇧🇭 .net.bh — Bahrain
 
 > The **.net.bh** is a country-code top-level domain (ccTLD) operated by CentralNic Group PLC. This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
 

--- a/scalar/content/tld-knowledge-base/cctlds/org.bh.md
+++ b/scalar/content/tld-knowledge-base/cctlds/org.bh.md
@@ -1,4 +1,4 @@
-# 🇬🇧 .org.bh — United Kingdom
+# 🇧🇭 .org.bh — Bahrain
 
 > The **.org.bh** is a country-code top-level domain (ccTLD) operated by CentralNic Group PLC. This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
 

--- a/scalar/scalar.config.json
+++ b/scalar/scalar.config.json
@@ -633,13 +633,13 @@
               },
               "/bh": {
                 "type": "page",
-                "title": "🌐 .bh",
+                "title": "🇧🇭 .bh",
                 "filepath": "content/tld-knowledge-base/cctlds/bh.md",
                 "showInSidebar": true
               },
               "/biz.bh": {
                 "type": "page",
-                "title": "🇬🇧 .biz.bh",
+                "title": "🇧🇭 .biz.bh",
                 "filepath": "content/tld-knowledge-base/cctlds/biz.bh.md",
                 "showInSidebar": true
               },
@@ -663,7 +663,7 @@
               },
               "/cc.bh": {
                 "type": "page",
-                "title": "🇨🇨 .cc.bh",
+                "title": "🇧🇭 .cc.bh",
                 "filepath": "content/tld-knowledge-base/cctlds/cc.bh.md",
                 "showInSidebar": true
               },
@@ -693,7 +693,7 @@
               },
               "/com.bh": {
                 "type": "page",
-                "title": "🇬🇧 .com.bh",
+                "title": "🇧🇭 .com.bh",
                 "filepath": "content/tld-knowledge-base/cctlds/com.bh.md",
                 "showInSidebar": true
               },
@@ -723,7 +723,7 @@
               },
               "/edu.bh": {
                 "type": "page",
-                "title": "🇬🇧 .edu.bh",
+                "title": "🇧🇭 .edu.bh",
                 "filepath": "content/tld-knowledge-base/cctlds/edu.bh.md",
                 "showInSidebar": true
               },
@@ -765,7 +765,7 @@
               },
               "/info.bh": {
                 "type": "page",
-                "title": "🇬🇧 .info.bh",
+                "title": "🇧🇭 .info.bh",
                 "filepath": "content/tld-knowledge-base/cctlds/info.bh.md",
                 "showInSidebar": true
               },
@@ -801,7 +801,7 @@
               },
               "/me.bh": {
                 "type": "page",
-                "title": "🇲🇪 .me.bh",
+                "title": "🇧🇭 .me.bh",
                 "filepath": "content/tld-knowledge-base/cctlds/me.bh.md",
                 "showInSidebar": true
               },
@@ -813,13 +813,13 @@
               },
               "/name.bh": {
                 "type": "page",
-                "title": "🇬🇧 .name.bh",
+                "title": "🇧🇭 .name.bh",
                 "filepath": "content/tld-knowledge-base/cctlds/name.bh.md",
                 "showInSidebar": true
               },
               "/net.bh": {
                 "type": "page",
-                "title": "🇬🇧 .net.bh",
+                "title": "🇧🇭 .net.bh",
                 "filepath": "content/tld-knowledge-base/cctlds/net.bh.md",
                 "showInSidebar": true
               },
@@ -831,7 +831,7 @@
               },
               "/org.bh": {
                 "type": "page",
-                "title": "🇬🇧 .org.bh",
+                "title": "🇧🇭 .org.bh",
                 "filepath": "content/tld-knowledge-base/cctlds/org.bh.md",
                 "showInSidebar": true
               },

--- a/scripts/tld_knowledge_base/countries.py
+++ b/scripts/tld_knowledge_base/countries.py
@@ -25,6 +25,7 @@ COUNTRY_NAMES: dict[str, str] = {
     "BA": "Bosnia and Herzegovina",
     "BE": "Belgium",
     "BG": "Bulgaria",
+    "BH": "Bahrain",
     "BR": "Brazil",
     "BS": "Bahamas",
     "BY": "Belarus",


### PR DESCRIPTION
BH was missing from COUNTRY_NAMES, so `.bh` rendered the globe fallback and every second-level `*.bh` domain inherited the wrong flag (cc.bh→Cocos, me.bh→Montenegro, biz/com/edu/info/name/net/org.bh →United Kingdom via the operator's registry country).

Adding "BH": "Bahrain" fixes the whole family at once, since tld_to_country_code now matches the trailing `bh` label.