### PR TITLE
docs: fix bulk-commands cross-link in vanity NS guide [DEV-1337]

### DIFF
--- a/scalar/content/dns/vanity-nameservers.md
+++ b/scalar/content/dns/vanity-nameservers.md
@@ -224,7 +224,7 @@ The target set must be <code>active</code> and belong to your organization. A su
 </scalar-callout>
 
 <scalar-callout type="info">
-To re-brand (or unbrand) <strong>many zones at once</strong>, use the bulk jobs API with the <code>dns_zone_restamp_vanity_ns_bulk</code> command — see <a href="/products/jobs/dns-commands">DNS bulk commands</a>.
+To re-brand (or unbrand) <strong>many zones at once</strong>, use the bulk jobs API with the <code>dns_zone_restamp_vanity_ns_bulk</code> command — see <a href="/automation/jobs/dns-commands">DNS bulk commands</a>.
 </scalar-callout>
 
 ### List the zones using a set


### PR DESCRIPTION
The cross-reference callout added in #71 linked to `/products/jobs/dns-commands`, which 404s — the jobs docs live under `/automation/jobs/...`. Corrects the link to `/automation/jobs/dns-commands` (matches how every other page links to it).