### PR TITLE
contacts are now conditionally optional for transfers

### DIFF
--- a/scalar/content/changelog.md
+++ b/scalar/content/changelog.md
@@ -4,6 +4,17 @@ Track notable updates to the OpusDNS API and developer documentation here.
 
 ## 2026
 
+### 30 June 2026
+
+- Made the **`contacts` section optional on domain transfers**. For TLDs that do
+  not require any contacts on an inbound transfer - where every supported contact
+  role has a minimum of `0` in the TLD specification (for example `.ca` and
+  `.ch`) - you can
+  now omit `contacts` entirely instead of sending an empty object. This applies to
+  `POST /v1/domains/transfer` as well as the `domain_transfer` and
+  `domain_transfer_bulk` job commands. TLDs that require one or more contact roles
+  still reject transfers submitted without them.
+
 ### 21 June 2026
 
 - Added **vanity nameservers** — serve your DNS zones under your own branded

--- a/scalar/content/domains/transfer-domain.md
+++ b/scalar/content/domains/transfer-domain.md
@@ -40,8 +40,12 @@ code proves you have the right to transfer the domain.
 
 ## 2. Prepare contacts
 
-Like registrations, transfers require `contacts` and `renewal_mode`. You can
+Most transfers require `contacts` alongside `renewal_mode`. You can
 reuse existing contacts or create new ones with `POST /v1/contacts`.
+
+<scalar-callout type="info">
+The <code>contacts</code> section is <strong>optional</strong> for TLDs that do not require any contacts to be supplied for an inbound transfer (i.e. every supported contact role has a minimum of <code>0</code> in the TLD specification, for example <code>.ca</code> and <code>.ch</code>). For those TLDs you can omit <code>contacts</code> entirely. TLDs that require one or more contact roles still reject transfers submitted without them.
+</scalar-callout>
 
 ```bash
 curl "$OPUSDNS_API_BASE/v1/contacts" \
@@ -102,7 +106,7 @@ curl "$OPUSDNS_API_BASE/v1/domains/transfer" \
 | --- | --- | --- |
 | `name` | Yes | The fully qualified domain name to transfer (e.g., `example.com`). |
 | `auth_code` | Yes | The authorization code from the current registrar. |
-| `contacts` | Yes | Contact IDs keyed by role. At minimum, a `registrant` is always required. |
+| `contacts` | Conditional | Contact IDs keyed by role. Required for most TLDs (a `registrant` is the minimum). Optional for TLDs where every supported contact role has a minimum of `0` (e.g. `.ca`, `.ch`). |
 | `renewal_mode` | Yes | `"renew"` for automatic renewal or `"expire"` to let the domain expire. |
 | `period` | No | Additional registration period added on transfer completion. If omitted, the registry default policy applies. |
 | `nameservers` | No | Nameservers to set after transfer completes. If omitted, the existing nameservers from the previous registrar are imported. See [Nameservers](/products/domains/nameservers) for the OpusDNS nameserver hostnames. Hostnames subordinate to a domain in your account must exist as [host objects](/products/domains/host-objects) first. |

--- a/scalar/content/jobs/domain-commands.md
+++ b/scalar/content/jobs/domain-commands.md
@@ -287,7 +287,7 @@ Initiate an inbound transfer for a single domain:
 | --- | --- | --- |
 | `name` | Yes | Domain name to transfer. |
 | `auth_code` | Yes | Authorization code from the current registrar (6–32 characters). |
-| `contacts` | Yes | Contact handles or IDs. |
+| `contacts` | Conditional | Contact handles or IDs. Required for most TLDs, but optional for TLDs where every supported contact role has a minimum of `0` (e.g. `.ca`, `.ch`). |
 | `renewal_mode` | Yes | Renewal mode after transfer. |
 | `period` | No | Transfer period. |
 | `nameservers` | No | Nameservers to set after transfer completes. |
@@ -323,7 +323,9 @@ Transfer multiple domains using the template + instances pattern:
 
 Each instance must include its own `auth_code` since authorization codes are
 unique per domain. Shared settings like contacts, renewal mode, and zone
-creation go in the template.
+creation go in the template. The `contacts` block can be omitted entirely for
+TLDs that do not require any contacts on transfer (every supported contact role
+has a minimum of `0`, e.g. `.ca`, `.ch`).
 
 ## Full batch example
 


### PR DESCRIPTION
### Description

Documents that the `contacts` section is now **optional on domain transfers**.
Some registries do not require any contacts for an inbound transfer — when a
TLD's `transfer_supported_roles` all define a minimum of `0` (e.g. `.ca`,
`.ch`), a transfer can be requested without providing any contacts at all, and
the `contacts` key can be omitted entirely rather than sending an empty `{}`.

This is a documentation-only update that follows the API changes which made
`contacts` optional on `DomainTransferIn` and the matching internal/bulk
transfer entry points (`DomainTransferReq`, `DomainTransferBulkTemplate`). The
OpenAPI spec (`src/openapi.yaml`) already reflected the relaxed schema, so this
PR brings the prose guides in line.

Changes:
- **`scalar/content/domains/transfer-domain.md`** — reworded the "Prepare
  contacts" step, added an info callout explaining when `contacts` may be
  omitted, and changed the `contacts` request field from **Yes** to
  **Conditional**.
- **`scalar/content/jobs/domain-commands.md`** — changed `contacts` to
  **Conditional** in the `domain_transfer` payload table and noted in
  `domain_transfer_bulk` that the `contacts` block can be omitted for TLDs that
  don't require it.
- **`scalar/content/changelog.md`** — added a 30 June 2026 entry describing the
  optional `contacts` behavior across the transfer endpoint and the
  `domain_transfer` / `domain_transfer_bulk` job commands.

### Testing

- Reviewed the rendered docs for the [Transfer a domain](/products/domains/transfer)
  and [Domain commands](/products/jobs/domain-commands) guides and the changelog.
- Confirmed no further required-`contacts` wording remains for transfers.
