### PR TITLE
docs: automatic DNSSEC reconciliation on transfers and NS changes [DEV-847]

### DIFF
--- a/scalar/content/changelog.md
+++ b/scalar/content/changelog.md
@@ -4,6 +4,15 @@ Track notable updates to the OpusDNS API and developer documentation here.
 
 ## 2026
 
+### 10 July 2026
+
+- Added **automatic DNSSEC reconciliation** on inbound transfers and nameserver
+  changes. Stale DS records imported from a previous DNS provider — which could
+  previously break resolution (`SERVFAIL`) once a domain moved to OpusDNS
+  nameservers — are now removed or replaced automatically. Domains on external
+  nameservers are never touched. See
+  [Automatic DNSSEC reconciliation](/products/domains/dnssec#automatic-dnssec-reconciliation).
+
 ### 07 July 2026
 
 - Onboarded **`.lu`** (Luxembourg). Published its

--- a/scalar/content/domains/dnssec.md
+++ b/scalar/content/domains/dnssec.md
@@ -97,6 +97,33 @@ curl "$OPUSDNS_API_BASE/v1/domains/example.com/dnssec" \
   --header "X-Api-Key: $OPUSDNS_API_KEY"
 ```
 
+## Automatic DNSSEC reconciliation
+
+When a domain transfers to OpusDNS, any DNSSEC records already published at
+the registry are imported along with the rest of the domain data. If those
+records point to keys held by a previous DNS provider, resolvers expect
+DNSSEC-signed responses that the new nameservers cannot produce, and the
+domain stops resolving (`SERVFAIL`).
+
+To prevent this, OpusDNS automatically reconciles the registry DNSSEC data
+with your zone's DNSSEC state after an inbound transfer completes and after
+a domain's nameservers change:
+
+| Nameservers | Zone DNSSEC status | Action |
+| --- | --- | --- |
+| External (not OpusDNS) | — | DNSSEC data is left untouched — you manage it yourself. |
+| OpusDNS | Enabled | The zone's current DNSSEC data is published to the registry, replacing any stale records. |
+| OpusDNS | Disabled, or no zone exists | All DNSSEC data is removed from the registry. |
+
+Reconciliation runs asynchronously after the transfer or nameserver update
+completes, so there may be a short delay before the registry records reflect
+the final state. It is skipped for TLDs that do not support DNSSEC.
+
+If reconciliation fails, a domain event with type `MODIFICATION` and subtype
+`FAILURE` is created — see the [Events overview](/products/events/overview).
+You can always inspect the current registry records with
+`GET /v1/domains/{domain_reference}/dnssec` and correct them manually.
+
 ## TLD support
 
 Not all TLDs support DNSSEC. The TLD specification includes:

--- a/scalar/content/domains/nameservers.md
+++ b/scalar/content/domains/nameservers.md
@@ -61,6 +61,11 @@ You can set nameservers at several points:
 - **After registration** — update nameservers with `PATCH /v1/domains/{domain_reference}`. See [Manage a domain](/products/domains/manage).
 - **In bulk** — use `domain_create_bulk`, `domain_transfer_bulk`, or `domain_update_bulk` in the [Jobs API](/automation/jobs/overview).
 
+When a domain's nameservers change, OpusDNS automatically reconciles the
+DNSSEC data published at the registry with the zone's DNSSEC state, so stale
+records from a previous provider cannot break resolution. See
+[Automatic DNSSEC reconciliation](/products/domains/dnssec#automatic-dnssec-reconciliation).
+
 ## Nameservers vs. zones
 
 Setting nameservers and creating a DNS zone are independent operations:

--- a/scalar/content/domains/transfer-domain.md
+++ b/scalar/content/domains/transfer-domain.md
@@ -190,6 +190,11 @@ Once the transfer completes:
 - Contacts are set to those provided in the transfer request.
 - Nameservers are updated if provided, otherwise the existing nameservers are imported from the previous registrar.
 - A DNS zone is created if `create_zone` was set to `true`.
+- Registry DNSSEC data is reconciled automatically: if the domain ends up on
+  OpusDNS nameservers, stale DS records imported from the previous provider are
+  removed or replaced so DNS resolution is not disrupted. Domains on external
+  nameservers are left untouched. See
+  [Automatic DNSSEC reconciliation](/products/domains/dnssec#automatic-dnssec-reconciliation).
 - A transfer event is created (check `/v1/events`).
 
 ## Troubleshooting


### PR DESCRIPTION
Documents the automatic DNSSEC reconciliation shipped in OpusDNS/opusdns-api#4814.

- New **Automatic DNSSEC reconciliation** section on the domain DNSSEC page (decision matrix, async timing, failure event)
- Cross-links from the transfer and nameservers guides
- Changelog entry (10 July 2026)

[DEV-847](https://opusdns.atlassian.net/browse/DEV-847)

https://claude.ai/code/session_01SBUUUgKKNR5UQVKZg1G56A

[DEV-847]: https://opusdns.atlassian.net/browse/DEV-847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ