### PR TITLE
docs: suborganization billing modes + changelog [DEV-1390]

### DIFF
--- a/scalar/content/account/manage-organizations.md
+++ b/scalar/content/account/manage-organizations.md
@@ -14,7 +14,7 @@ curl "$OPUSDNS_API_BASE/v1/organizations" \
     "name": "Customer A",
     "country_code": "DE",
     "city": "Berlin",
-    "address": "Friedrichstraße 123",
+    "address_1": "Friedrichstraße 123",
     "postal_code": "10117",
     "currency": "EUR",
     "default_locale": "de"
@@ -26,9 +26,11 @@ curl "$OPUSDNS_API_BASE/v1/organizations" \
 | Field | Required | Description |
 | --- | --- | --- |
 | `name` | Yes | Display name for the organization. |
+| `billing_mode` | No | `consolidated` (default) or `independent` — see [Billing modes](#billing-modes). **Cannot be changed after creation.** |
 | `country_code` | No | ISO 3166-1 alpha-2 country code. |
 | `city` | No | City. |
-| `address` | No | Street address. |
+| `address_1` | No | First line of the street address. |
+| `address_2` | No | Second line of the street address. |
 | `postal_code` | No | Postal or ZIP code. |
 | `state` | No | State or province. |
 | `currency` | No | Default currency for billing. |
@@ -55,7 +57,7 @@ curl "$OPUSDNS_API_BASE/v1/organizations" \
     "name": "Customer A",
     "country_code": "DE",
     "city": "Berlin",
-    "address": "Friedrichstraße 123",
+    "address_1": "Friedrichstraße 123",
     "postal_code": "10117",
     "currency": "EUR",
     "users": [
@@ -63,19 +65,109 @@ curl "$OPUSDNS_API_BASE/v1/organizations" \
         "username": "customer-a-admin",
         "email": "admin@customer-a.com",
         "first_name": "Alice",
-        "last_name": "Admin"
+        "last_name": "Admin",
+        "locale": "de_DE"
       },
       {
         "username": "customer-a-tech",
         "email": "tech@customer-a.com",
         "first_name": "Bob",
-        "last_name": "Tech"
+        "last_name": "Tech",
+        "locale": "de_DE"
       }
     ]
   }'
 ```
 
+Each user requires `username`, `email`, `first_name`, `last_name`, and
+`locale` (underscore form, e.g. `en_US`). The **first user in the list becomes
+the organization's owner**; subsequent users are created as admins.
+
 You can add more users later with the [User management](/account/users) API.
+
+## Billing modes
+
+Every suborganization is created in one of two billing modes, set with the
+`billing_mode` field on the create request:
+
+| | `consolidated` (default) | `independent` |
+| --- | --- | --- |
+| Charges & invoices | Roll up to your (parent) account | The suborganization's own account |
+| Wallet & payment methods | Yours | Its own wallet, balance, and payment methods |
+| Extra required fields | None | `currency`, `country_code` |
+
+**`billing_mode` is permanent.** It cannot be changed after creation — an
+update request that includes `billing_mode` is rejected. Choose deliberately;
+converting an organization between modes means deleting and recreating it.
+
+### Creating an independent suborganization
+
+```bash
+curl "$OPUSDNS_API_BASE/v1/organizations" \
+  --request POST \
+  --header "X-Api-Key: $OPUSDNS_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "name": "Customer B (self-billed)",
+    "billing_mode": "independent",
+    "currency": "EUR",
+    "country_code": "DE",
+    "address_1": "Friedrichstraße 123",
+    "city": "Berlin",
+    "postal_code": "10117",
+    "tax_id": "DE123456789",
+    "users": [
+      {
+        "username": "customer-b-owner",
+        "email": "billing@customer-b.example",
+        "first_name": "Carol",
+        "last_name": "Owner",
+        "locale": "de_DE"
+      }
+    ]
+  }'
+```
+
+Requirements and behavior:
+
+- **`currency`** is required and must be `EUR` or `USD`. It becomes the
+  organization's billing currency permanently.
+- **`country_code`** is required.
+- A **billing contact** is needed: the first user in `users[]` is used if
+  present, otherwise your parent organization's owner. Include a full street
+  address at creation — it is required later for checkout and balance top-ups.
+- Provisioning is **synchronous and all-or-nothing**: a successful response
+  means the organization's billing account, wallet, and payment setup all
+  exist. If anything fails, nothing is created.
+- New independent suborganizations start on **prepaid** terms. Contact support
+  to arrange different payment terms.
+
+### Errors
+
+| HTTP | Error code | Meaning |
+| --- | --- | --- |
+| 422 | `ERROR_INDEPENDENT_BILLING_NOT_ALLOWED` | Independent billing is only available for suborganizations created directly under your top-level (billing) organization. |
+| 422 | `ERROR_INDEPENDENT_BILLING_ATTRIBUTES_INVALID` | `currency` or `country_code` missing or invalid — the response lists every problem in `invalid_fields`. |
+| 422 | `ERROR_INDEPENDENT_BILLING_CONTACT_NOT_FOUND` | No billing contact could be resolved — include a user in `users[]`. |
+
+### Viewing an independent suborganization's billing
+
+An independent suborganization sees its own invoices, transactions, and
+billing data through the normal billing endpoints. As the parent, you can view
+a suborganization's billing by sending its ID in the `X-Organization-Context`
+header on those same endpoints:
+
+```bash
+curl "$OPUSDNS_API_BASE/v1/organizations/organization_01h45.../transactions" \
+  --header "X-Api-Key: $OPUSDNS_API_KEY" \
+  --header "X-Organization-Context: organization_01h46..."
+```
+
+For a consolidated view of spend across your whole organization tree —
+including independent suborganizations — a monthly **suborganization billing
+transactions report** is available via the [Reports API](/api-reference#tag/report):
+each row is one transaction, with columns for the organization that incurred
+it and the organization that was billed for it.
 
 ## Listing suborganizations
 

--- a/scalar/content/changelog.md
+++ b/scalar/content/changelog.md
@@ -4,7 +4,7 @@ Track notable updates to the OpusDNS API and developer documentation here.
 
 ## 2026
 
-### 16 July 2026
+### 17 July 2026
 
 - Added **independent billing for suborganizations**: create a suborganization
   with `billing_mode: "independent"` and it gets its own wallet, invoices, and

--- a/scalar/content/changelog.md
+++ b/scalar/content/changelog.md
@@ -4,6 +4,16 @@ Track notable updates to the OpusDNS API and developer documentation here.
 
 ## 2026
 
+### 16 July 2026
+
+- Added **independent billing for suborganizations**: create a suborganization
+  with `billing_mode: "independent"` and it gets its own wallet, invoices, and
+  payment methods instead of rolling up to your account. Consolidated billing
+  remains the default and is unchanged. Also added the monthly
+  **suborganization billing transactions report** covering spend across your
+  whole organization tree. See
+  [Billing modes](/account/organizations/manage#billing-modes).
+
 ### 10 July 2026
 
 - Added **automatic DNSSEC reconciliation** on inbound transfers and nameserver


### PR DESCRIPTION
Adds the independent/consolidated billing-mode section to the Manage suborganizations guide + changelog entry.

**HOLD: merge at public launch** (feature flag is still off in production). Re-date the changelog entry at merge if needed.

Also fixes two pre-existing errors in the create examples: `address` → `address_1` (field doesn't exist under that name) and missing required `locale` on users.

https://claude.ai/code/session_01L9xNFBxdASWmCHX5yk7yfn