### PR TITLE
Remove `.lv` TLD from WIP + KB page

### DIFF
--- a/scalar/content/tld-knowledge-base/_notes/lv.md
+++ b/scalar/content/tld-knowledge-base/_notes/lv.md
@@ -1,0 +1,63 @@
+## Contact Attributes
+
+`.lv` uses the **LvContact** EPP extension (`http://www.nic.lv/epp/schema/lvcontact-ext-1.0`) to carry two registry-specific identifiers. They are only relevant when a contact is used as the **registrant** (holder) of a domain; admin and tech contacts never carry them.
+
+| Attribute | Type | Required | Applies to | Notes |
+| --- | --- | --- | --- | --- |
+| `NIC_LV_REG_NR` | String | Conditional | Registrant | Personal code (Latvian natural person) or enterprise registration number (Latvian company). Required for a Latvian registrant. |
+| `NIC_LV_VAT_NR` | String | Optional | Registrant | EU VAT number. Used by a foreign EU legal entity (and, optionally, a Latvian company). |
+
+### What each identifier is
+
+- **`NIC_LV_REG_NR`** maps to `lvcontact:regNr`:
+   - for a Latvian **natural person** (no `org`), it holds the personal code (e.g. `010171-10123`);
+   - for a Latvian **company** (with `org`), it holds the registration number from the Latvian Register of Enterprises.
+- **`NIC_LV_VAT_NR`** maps to `lvcontact:vatNr`: the EU VAT number (e.g. `LV40003014197`).
+
+Whether a contact is a legal entity or a natural person is decided by the presence or absence of `org`: a non-empty `org` means a legal entity, otherwise a natural person. The registry validates the deeper semantics (real personal code, enterprise number, VAT) itself.
+
+### Who provides what
+
+`.lv` has **no local-presence requirement**: a registrant may be a Latvian or a foreign person or company.
+
+| Registrant | `NIC_LV_REG_NR` | `NIC_LV_VAT_NR` | LvContact extension sent |
+| --- | --- | --- | --- |
+| Latvian company | Enterprise registration number | VAT (optional) | ✅ |
+| Latvian natural person | Personal code | - | ✅ |
+| Foreign EU legal entity | - | EU VAT number | ✅ (vatNr only) |
+| Foreign non-EU | - | - | ❌ (no extension) |
+
+Only the validation we can enforce up front is applied: a Latvian registrant must carry `NIC_LV_REG_NR`, and any value provided must satisfy the registry schema (`lvcontact:orgRegNoType`: 3-20 characters of letters, digits and `#:./-`). The full personal-code / VAT semantics are left to the registry. These rules run only for `.lv` domain operations; they are never enforced on the generic contact endpoint.
+
+## Per-role rules
+
+`.lv` always associates four contacts with a domain, but only two are managed by the registrar:
+
+- **registrant** and **administrative** contacts are sent by us;
+- **billing** (the registrar's primary person) and **technical** (one of the registrar's hostmasters) are assigned by the registry through `__DEFAULT__`, so they are not part of the request.
+
+Cross-role rules enforced before the request reaches the registry:
+
+- the **administrative contact must be a natural person** (no `org`);
+- when the holder (registrant) is a **natural person**, the administrative contact must reference the **same contact** as the registrant;
+- changing the registrant is a **trade** (transfer of the right to use the domain), performed through `domain:update` with a new holder, not a contact swap.
+
+## Nameservers
+
+`.lv` does **not** implement host objects (RFC 5732). Nameservers are attributes of the domain and are sent as `domain:hostAttr`; a subordinate (in-bailiwick) host carries its glue address inline. Between 2 and 5 nameservers are allowed, and at least 2 are required for the domain to be published in the zone.
+
+## Postal address
+
+Only a single `loc` postal address is accepted; an `int`-only contact is rejected by the registry with `2003 Missing postal address for contact!`. For Latvian contacts (`cc = LV`) the registry expects the postal code in `LV-NNNN` form (four digits), but this is a registry-side rule and is never forced from the generic contact endpoint.
+
+## Registration period and renewal
+
+Only **1-year** registrations are accepted over EPP. There is no EPP `domain:renew` command on `.lv`; renewal is handled by the registry out of band (invoicing). An unpaid or breached domain enters a **30-day hold** before deletion.
+
+## AuthInfo
+
+The domain authInfo must be acceptable to the registry's runtime password policy; a reused or weak value is rejected with `2306 Please, choose different AuthInfo`. A freshly generated random auth code is used, which always satisfies it.
+
+## IDN
+
+The registry is IDN-capable (Latvian diacritics), but IDN support is **not enabled** for `.lv` in our configuration yet.

--- a/scalar/content/tld-knowledge-base/_notes/lv.md
+++ b/scalar/content/tld-knowledge-base/_notes/lv.md
@@ -44,3 +44,12 @@ A `.lv` domain is managed with a registrant and an administrative contact. Two r
 >   "detail": "Policy validation failed"
 > }
 > ```
+
+## Transfers
+
+On an inbound transfer the registrant and administrative contact are preserved as they already are on the domain — they cannot be set in the transfer request:
+
+- the **registrant** cannot be changed through a transfer or a domain update;
+- the **administrative contact** is kept during the transfer. When the registrant is an organization, the admin is a separate individual and can be changed with a domain update afterwards. When the registrant is a natural person, the admin is the same contact as the registrant, so it changes only when the registrant changes.
+
+The billing and technical contacts are managed automatically and are set when the transfer completes; they are not part of the transfer request.

--- a/scalar/content/tld-knowledge-base/_notes/lv.md
+++ b/scalar/content/tld-knowledge-base/_notes/lv.md
@@ -1,63 +1,46 @@
 ## Contact Attributes
 
-`.lv` uses the **LvContact** EPP extension (`http://www.nic.lv/epp/schema/lvcontact-ext-1.0`) to carry two registry-specific identifiers. They are only relevant when a contact is used as the **registrant** (holder) of a domain; admin and tech contacts never carry them.
+`.lv` registrations carry two registry-specific contact attributes beyond the standard EPP fields. They identify the **registrant** (holder) of the domain:
 
-| Attribute | Type | Required | Applies to | Notes |
+| Attribute | Type | Required | Applies to | Allowed values |
 | --- | --- | --- | --- | --- |
-| `NIC_LV_REG_NR` | String | Conditional | Registrant | Personal code (Latvian natural person) or enterprise registration number (Latvian company). Required for a Latvian registrant. |
-| `NIC_LV_VAT_NR` | String | Optional | Registrant | EU VAT number. Used by a foreign EU legal entity (and, optionally, a Latvian company). |
+| `NIC_LV_REG_NR` | String | ➖ Conditional | Registrant | Registration number, 3-20 characters (letters, digits and `#:./-`) |
+| `NIC_LV_VAT_NR` | String | ➖ Conditional | Registrant | VAT number, 3-20 characters (letters, digits and `#:./-`) |
 
-### What each identifier is
+- `NIC_LV_REG_NR` holds a **registration number**: a personal code for a natural person, or a company registration number for a legal entity.
+- `NIC_LV_VAT_NR` holds a **VAT number**.
 
-- **`NIC_LV_REG_NR`** maps to `lvcontact:regNr`:
-   - for a Latvian **natural person** (no `org`), it holds the personal code (e.g. `010171-10123`);
-   - for a Latvian **company** (with `org`), it holds the registration number from the Latvian Register of Enterprises.
-- **`NIC_LV_VAT_NR`** maps to `lvcontact:vatNr`: the EU VAT number (e.g. `LV40003014197`).
+Which attribute is required depends on the registrant:
 
-Whether a contact is a legal entity or a natural person is decided by the presence or absence of `org`: a non-empty `org` means a legal entity, otherwise a natural person. The registry validates the deeper semantics (real personal code, enterprise number, VAT) itself.
+| Registrant | Required attribute |
+| --- | --- |
+| Latvian (natural person or legal entity) | `NIC_LV_REG_NR` |
+| Foreign EU legal entity | `NIC_LV_VAT_NR` |
+| Foreign non-EU | none |
 
-### Who provides what
+These constraints are machine-readable: each `possible_attributes` entry returned by [`GET /v1/tlds/lv`](/api-reference#tag/tld/GET/v1/tlds/{tld}) carries its own `type`, `required`, and `contact_roles` fields.
 
-`.lv` has **no local-presence requirement**: a registrant may be a Latvian or a foreign person or company.
+## Contact roles
 
-| Registrant | `NIC_LV_REG_NR` | `NIC_LV_VAT_NR` | LvContact extension sent |
-| --- | --- | --- | --- |
-| Latvian company | Enterprise registration number | VAT (optional) | ✅ |
-| Latvian natural person | Personal code | - | ✅ |
-| Foreign EU legal entity | - | EU VAT number | ✅ (vatNr only) |
-| Foreign non-EU | - | - | ❌ (no extension) |
-
-Only the validation we can enforce up front is applied: a Latvian registrant must carry `NIC_LV_REG_NR`, and any value provided must satisfy the registry schema (`lvcontact:orgRegNoType`: 3-20 characters of letters, digits and `#:./-`). The full personal-code / VAT semantics are left to the registry. These rules run only for `.lv` domain operations; they are never enforced on the generic contact endpoint.
-
-## Per-role rules
-
-`.lv` always associates four contacts with a domain, but only two are managed by the registrar:
-
-- **registrant** and **administrative** contacts are sent by us;
-- **billing** (the registrar's primary person) and **technical** (one of the registrar's hostmasters) are assigned by the registry through `__DEFAULT__`, so they are not part of the request.
-
-Cross-role rules enforced before the request reaches the registry:
+A `.lv` domain is managed with a registrant and an administrative contact. Two role rules apply:
 
 - the **administrative contact must be a natural person** (no `org`);
-- when the holder (registrant) is a **natural person**, the administrative contact must reference the **same contact** as the registrant;
-- changing the registrant is a **trade** (transfer of the right to use the domain), performed through `domain:update` with a new holder, not a contact swap.
+- when the **registrant is a natural person**, the administrative contact must reference the **same contact** as the registrant.
 
-## Nameservers
-
-`.lv` does **not** implement host objects (RFC 5732). Nameservers are attributes of the domain and are sent as `domain:hostAttr`; a subordinate (in-bailiwick) host carries its glue address inline. Between 2 and 5 nameservers are allowed, and at least 2 are required for the domain to be published in the zone.
-
-## Postal address
-
-Only a single `loc` postal address is accepted; an `int`-only contact is rejected by the registry with `2003 Missing postal address for contact!`. For Latvian contacts (`cc = LV`) the registry expects the postal code in `LV-NNNN` form (four digits), but this is a registry-side rule and is never forced from the generic contact endpoint.
-
-## Registration period and renewal
-
-Only **1-year** registrations are accepted over EPP. There is no EPP `domain:renew` command on `.lv`; renewal is handled by the registry out of band (invoicing). An unpaid or breached domain enters a **30-day hold** before deletion.
-
-## AuthInfo
-
-The domain authInfo must be acceptable to the registry's runtime password policy; a reused or weak value is rejected with `2306 Please, choose different AuthInfo`. A freshly generated random auth code is used, which always satisfies it.
-
-## IDN
-
-The registry is IDN-capable (Latvian diacritics), but IDN support is **not enabled** for `.lv` in our configuration yet.
+> ⚠️ **Reusing one contact for every role?** When the registrant is a natural person, the admin has to be that same contact:
+>
+> ```json
+> {
+>   "type": "policy-validation-error",
+>   "title": "Policy Validation Error",
+>   "status": 422,
+>   "code": "ERROR_POLICY_VALIDATION",
+>   "errors": [
+>     {
+>       "detail": "When the .lv holder is a natural person, the administrative contact must be the same contact as the registrant",
+>       "pointer": "contacts.admin"
+>     }
+>   ],
+>   "detail": "Policy validation failed"
+> }
+> ```

--- a/scalar/content/tld-knowledge-base/cctlds/lv.md
+++ b/scalar/content/tld-knowledge-base/cctlds/lv.md
@@ -101,64 +101,47 @@
 
 ## Contact Attributes
 
-`.lv` uses the **LvContact** EPP extension (`http://www.nic.lv/epp/schema/lvcontact-ext-1.0`) to carry two registry-specific identifiers. They are only relevant when a contact is used as the **registrant** (holder) of a domain; admin and tech contacts never carry them.
+`.lv` registrations carry two registry-specific contact attributes beyond the standard EPP fields. They identify the **registrant** (holder) of the domain:
 
-| Attribute | Type | Required | Applies to | Notes |
+| Attribute | Type | Required | Applies to | Allowed values |
 | --- | --- | --- | --- | --- |
-| `NIC_LV_REG_NR` | String | Conditional | Registrant | Personal code (Latvian natural person) or enterprise registration number (Latvian company). Required for a Latvian registrant. |
-| `NIC_LV_VAT_NR` | String | Optional | Registrant | EU VAT number. Used by a foreign EU legal entity (and, optionally, a Latvian company). |
+| `NIC_LV_REG_NR` | String | ➖ Conditional | Registrant | Registration number, 3-20 characters (letters, digits and `#:./-`) |
+| `NIC_LV_VAT_NR` | String | ➖ Conditional | Registrant | VAT number, 3-20 characters (letters, digits and `#:./-`) |
 
-### What each identifier is
+- `NIC_LV_REG_NR` holds a **registration number**: a personal code for a natural person, or a company registration number for a legal entity.
+- `NIC_LV_VAT_NR` holds a **VAT number**.
 
-- **`NIC_LV_REG_NR`** maps to `lvcontact:regNr`:
-   - for a Latvian **natural person** (no `org`), it holds the personal code (e.g. `010171-10123`);
-   - for a Latvian **company** (with `org`), it holds the registration number from the Latvian Register of Enterprises.
-- **`NIC_LV_VAT_NR`** maps to `lvcontact:vatNr`: the EU VAT number (e.g. `LV40003014197`).
+Which attribute is required depends on the registrant:
 
-Whether a contact is a legal entity or a natural person is decided by the presence or absence of `org`: a non-empty `org` means a legal entity, otherwise a natural person. The registry validates the deeper semantics (real personal code, enterprise number, VAT) itself.
+| Registrant | Required attribute |
+| --- | --- |
+| Latvian (natural person or legal entity) | `NIC_LV_REG_NR` |
+| Foreign EU legal entity | `NIC_LV_VAT_NR` |
+| Foreign non-EU | none |
 
-### Who provides what
+These constraints are machine-readable: each `possible_attributes` entry returned by [`GET /v1/tlds/lv`](/api-reference#tag/tld/GET/v1/tlds/{tld}) carries its own `type`, `required`, and `contact_roles` fields.
 
-`.lv` has **no local-presence requirement**: a registrant may be a Latvian or a foreign person or company.
+## Contact roles
 
-| Registrant | `NIC_LV_REG_NR` | `NIC_LV_VAT_NR` | LvContact extension sent |
-| --- | --- | --- | --- |
-| Latvian company | Enterprise registration number | VAT (optional) | ✅ |
-| Latvian natural person | Personal code | - | ✅ |
-| Foreign EU legal entity | - | EU VAT number | ✅ (vatNr only) |
-| Foreign non-EU | - | - | ❌ (no extension) |
-
-Only the validation we can enforce up front is applied: a Latvian registrant must carry `NIC_LV_REG_NR`, and any value provided must satisfy the registry schema (`lvcontact:orgRegNoType`: 3-20 characters of letters, digits and `#:./-`). The full personal-code / VAT semantics are left to the registry. These rules run only for `.lv` domain operations; they are never enforced on the generic contact endpoint.
-
-## Per-role rules
-
-`.lv` always associates four contacts with a domain, but only two are managed by the registrar:
-
-- **registrant** and **administrative** contacts are sent by us;
-- **billing** (the registrar's primary person) and **technical** (one of the registrar's hostmasters) are assigned by the registry through `__DEFAULT__`, so they are not part of the request.
-
-Cross-role rules enforced before the request reaches the registry:
+A `.lv` domain is managed with a registrant and an administrative contact. Two role rules apply:
 
 - the **administrative contact must be a natural person** (no `org`);
-- when the holder (registrant) is a **natural person**, the administrative contact must reference the **same contact** as the registrant;
-- changing the registrant is a **trade** (transfer of the right to use the domain), performed through `domain:update` with a new holder, not a contact swap.
+- when the **registrant is a natural person**, the administrative contact must reference the **same contact** as the registrant.
 
-## Nameservers
-
-`.lv` does **not** implement host objects (RFC 5732). Nameservers are attributes of the domain and are sent as `domain:hostAttr`; a subordinate (in-bailiwick) host carries its glue address inline. Between 2 and 5 nameservers are allowed, and at least 2 are required for the domain to be published in the zone.
-
-## Postal address
-
-Only a single `loc` postal address is accepted; an `int`-only contact is rejected by the registry with `2003 Missing postal address for contact!`. For Latvian contacts (`cc = LV`) the registry expects the postal code in `LV-NNNN` form (four digits), but this is a registry-side rule and is never forced from the generic contact endpoint.
-
-## Registration period and renewal
-
-Only **1-year** registrations are accepted over EPP. There is no EPP `domain:renew` command on `.lv`; renewal is handled by the registry out of band (invoicing). An unpaid or breached domain enters a **30-day hold** before deletion.
-
-## AuthInfo
-
-The domain authInfo must be acceptable to the registry's runtime password policy; a reused or weak value is rejected with `2306 Please, choose different AuthInfo`. A freshly generated random auth code is used, which always satisfies it.
-
-## IDN
-
-The registry is IDN-capable (Latvian diacritics), but IDN support is **not enabled** for `.lv` in our configuration yet.
+> ⚠️ **Reusing one contact for every role?** When the registrant is a natural person, the admin has to be that same contact:
+>
+> ```json
+> {
+>   "type": "policy-validation-error",
+>   "title": "Policy Validation Error",
+>   "status": 422,
+>   "code": "ERROR_POLICY_VALIDATION",
+>   "errors": [
+>     {
+>       "detail": "When the .lv holder is a natural person, the administrative contact must be the same contact as the registrant",
+>       "pointer": "contacts.admin"
+>     }
+>   ],
+>   "detail": "Policy validation failed"
+> }
+> ```

--- a/scalar/content/tld-knowledge-base/cctlds/lv.md
+++ b/scalar/content/tld-knowledge-base/cctlds/lv.md
@@ -1,0 +1,164 @@
+# 🇱🇻 .lv — Latvia
+
+> The **.lv** is a country-code top-level domain (ccTLD) operated by Network Information Centre (NIC), Institute of Mathematics and Computer Science, University of Latvia. This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
+
+## General Information
+
+| Property | Value |
+| --- | --- |
+| TLD Type | ccTLD |
+| Registry | Network Information Centre (NIC), Institute of Mathematics and Computer Science, University of Latvia |
+| Registry Country | Latvia |
+| Registry Website | [www.nic.lv](https://www.nic.lv) |
+| Provisioning Protocol | EPP |
+| Second-Level Registration | ❌ No |
+| Accreditation Required | ✅ Yes |
+
+## Domain Lifecycle
+
+| Property | Value |
+| --- | --- |
+| Registration Period | 1 year |
+| Renewal Period | 1 year |
+| Transfer Renewal Period | 1 year |
+| Deletion Policy | Immediate |
+| Auto-Renew Enabled | ❌ No |
+| Auto-Renewal Before Expiry | On expiration |
+| Sync After Operations | registration, transfer |
+
+**Grace periods**
+
+| Period | Duration |
+| --- | --- |
+| Add Grace Period | 0 days |
+| Standard Grace Period | 30 days |
+| Redemption Period | 0 days |
+| Pending Restore | 0 days |
+| Pending Delete | 0 days |
+
+## Launch Phases & Availability
+
+| Property | Value |
+| --- | --- |
+| General Availability | ✅ TLD is live |
+| TMCH / Trademark Claims | ❌ No |
+
+## Domain Characteristics
+
+| Property | Value |
+| --- | --- |
+| Domain Length | 2–63 characters |
+| IDN Support | ❌ No |
+| Premium Domains | ❌ No |
+| Reserved Domains | ❌ No |
+| Registry Lock | ❌ No |
+
+## Contacts & Roles
+
+| Property | Value |
+| --- | --- |
+| Required Contacts | Domain Owner, Administrator |
+| Supported Roles | Domain Owner, Administrator |
+| Thick WHOIS | ✅ Yes |
+| Privacy Proxy Allowed | ❌ No |
+| Contacts Transferable | ❌ No |
+| Allowed Postal Types | Local |
+| AuthInfo Required | ✅ Yes (12–63 characters) |
+
+## Nameservers & DNS
+
+| Property | Value |
+| --- | --- |
+| Nameserver Count | 2–5 |
+| Host Objects Allowed | ❌ No |
+| Registry Nameserver Check | ✅ Yes |
+| DNSSEC Allowed | ✅ Yes |
+| DNSSEC Required | ❌ No |
+| DNSSEC Mode | DS |
+| CZDS (Zone Download) | ❌ No |
+
+## Transfer Policy
+
+| Property | Value |
+| --- | --- |
+| Transfer Lock Enabled | ✅ Yes (60 days after registration; 60 days after transfer) |
+| Transfer Duration | 5 days |
+| Transfer Extends Domain | ✅ Yes (+1 year) |
+| Transfer via AuthInfo | ✅ Yes |
+| Confirmation Required | ✅ Yes (Both parties) |
+
+## WHOIS & RDAP
+
+| Property | Value |
+| --- | --- |
+| WHOIS Server | `whois.nic.lv` |
+
+## Dispute Resolution
+
+| Property | Value |
+| --- | --- |
+| Dispute Resolution Available | ❌ No |
+
+## Contact Attributes
+
+`.lv` uses the **LvContact** EPP extension (`http://www.nic.lv/epp/schema/lvcontact-ext-1.0`) to carry two registry-specific identifiers. They are only relevant when a contact is used as the **registrant** (holder) of a domain; admin and tech contacts never carry them.
+
+| Attribute | Type | Required | Applies to | Notes |
+| --- | --- | --- | --- | --- |
+| `NIC_LV_REG_NR` | String | Conditional | Registrant | Personal code (Latvian natural person) or enterprise registration number (Latvian company). Required for a Latvian registrant. |
+| `NIC_LV_VAT_NR` | String | Optional | Registrant | EU VAT number. Used by a foreign EU legal entity (and, optionally, a Latvian company). |
+
+### What each identifier is
+
+- **`NIC_LV_REG_NR`** maps to `lvcontact:regNr`:
+   - for a Latvian **natural person** (no `org`), it holds the personal code (e.g. `010171-10123`);
+   - for a Latvian **company** (with `org`), it holds the registration number from the Latvian Register of Enterprises.
+- **`NIC_LV_VAT_NR`** maps to `lvcontact:vatNr`: the EU VAT number (e.g. `LV40003014197`).
+
+Whether a contact is a legal entity or a natural person is decided by the presence or absence of `org`: a non-empty `org` means a legal entity, otherwise a natural person. The registry validates the deeper semantics (real personal code, enterprise number, VAT) itself.
+
+### Who provides what
+
+`.lv` has **no local-presence requirement**: a registrant may be a Latvian or a foreign person or company.
+
+| Registrant | `NIC_LV_REG_NR` | `NIC_LV_VAT_NR` | LvContact extension sent |
+| --- | --- | --- | --- |
+| Latvian company | Enterprise registration number | VAT (optional) | ✅ |
+| Latvian natural person | Personal code | - | ✅ |
+| Foreign EU legal entity | - | EU VAT number | ✅ (vatNr only) |
+| Foreign non-EU | - | - | ❌ (no extension) |
+
+Only the validation we can enforce up front is applied: a Latvian registrant must carry `NIC_LV_REG_NR`, and any value provided must satisfy the registry schema (`lvcontact:orgRegNoType`: 3-20 characters of letters, digits and `#:./-`). The full personal-code / VAT semantics are left to the registry. These rules run only for `.lv` domain operations; they are never enforced on the generic contact endpoint.
+
+## Per-role rules
+
+`.lv` always associates four contacts with a domain, but only two are managed by the registrar:
+
+- **registrant** and **administrative** contacts are sent by us;
+- **billing** (the registrar's primary person) and **technical** (one of the registrar's hostmasters) are assigned by the registry through `__DEFAULT__`, so they are not part of the request.
+
+Cross-role rules enforced before the request reaches the registry:
+
+- the **administrative contact must be a natural person** (no `org`);
+- when the holder (registrant) is a **natural person**, the administrative contact must reference the **same contact** as the registrant;
+- changing the registrant is a **trade** (transfer of the right to use the domain), performed through `domain:update` with a new holder, not a contact swap.
+
+## Nameservers
+
+`.lv` does **not** implement host objects (RFC 5732). Nameservers are attributes of the domain and are sent as `domain:hostAttr`; a subordinate (in-bailiwick) host carries its glue address inline. Between 2 and 5 nameservers are allowed, and at least 2 are required for the domain to be published in the zone.
+
+## Postal address
+
+Only a single `loc` postal address is accepted; an `int`-only contact is rejected by the registry with `2003 Missing postal address for contact!`. For Latvian contacts (`cc = LV`) the registry expects the postal code in `LV-NNNN` form (four digits), but this is a registry-side rule and is never forced from the generic contact endpoint.
+
+## Registration period and renewal
+
+Only **1-year** registrations are accepted over EPP. There is no EPP `domain:renew` command on `.lv`; renewal is handled by the registry out of band (invoicing). An unpaid or breached domain enters a **30-day hold** before deletion.
+
+## AuthInfo
+
+The domain authInfo must be acceptable to the registry's runtime password policy; a reused or weak value is rejected with `2306 Please, choose different AuthInfo`. A freshly generated random auth code is used, which always satisfies it.
+
+## IDN
+
+The registry is IDN-capable (Latvian diacritics), but IDN support is **not enabled** for `.lv` in our configuration yet.

--- a/scalar/content/tld-knowledge-base/cctlds/lv.md
+++ b/scalar/content/tld-knowledge-base/cctlds/lv.md
@@ -11,7 +11,7 @@
 | Registry Country | Latvia |
 | Registry Website | [www.nic.lv](https://www.nic.lv) |
 | Provisioning Protocol | EPP |
-| Second-Level Registration | ❌ No |
+| Second-Level Registration | ✅ Yes |
 | Accreditation Required | ✅ Yes |
 
 ## Domain Lifecycle
@@ -145,3 +145,12 @@ A `.lv` domain is managed with a registrant and an administrative contact. Two r
 >   "detail": "Policy validation failed"
 > }
 > ```
+
+## Transfers
+
+On an inbound transfer the registrant and administrative contact are preserved as they already are on the domain — they cannot be set in the transfer request:
+
+- the **registrant** cannot be changed through a transfer or a domain update;
+- the **administrative contact** is kept during the transfer. When the registrant is an organization, the admin is a separate individual and can be changed with a domain update afterwards. When the registrant is a natural person, the admin is the same contact as the registrant, so it changes only when the registrant changes.
+
+The billing and technical contacts are managed automatically and are set when the transfer completes; they are not part of the transfer request.

--- a/scalar/scalar.config.json
+++ b/scalar/scalar.config.json
@@ -813,6 +813,12 @@
                 "filepath": "content/tld-knowledge-base/cctlds/lu.md",
                 "showInSidebar": true
               },
+              "/lv": {
+                "type": "page",
+                "title": "🇱🇻 .lv",
+                "filepath": "content/tld-knowledge-base/cctlds/lv.md",
+                "showInSidebar": true
+              },
               "/me": {
                 "type": "page",
                 "title": "🇲🇪 .me",

--- a/scripts/tld_knowledge_base/excluded_tlds.txt
+++ b/scripts/tld_knowledge_base/excluded_tlds.txt
@@ -5,4 +5,3 @@
 si # no pricing yet
 lt # WIP
 ua # WIP
-lv # WIP


### PR DESCRIPTION
Removes `.lv` from the WIP TLDs and adds the generated KB page + hand-written `_notes/lv.md` (contact attributes, role rules, transfer contact behaviour).