### PR TITLE
ci: notify opusdns-mcp when the published spec changes

### DIFF
--- a/.github/workflows/generate-ts-types.yaml
+++ b/.github/workflows/generate-ts-types.yaml
@@ -61,12 +61,14 @@ jobs:
         run: npm run generate:helpers
 
       - name: Commit & Push Changes
+        id: commit
         run: |
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
           git add .
           if git diff --staged --quiet; then
             echo "No changes to commit."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             mv openapi.yaml src/openapi.yaml
             npm run generate:schema
@@ -78,4 +80,21 @@ jobs:
             npm version minor
             git push
             npm publish --access public
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            # The pushed SHA, not github.sha, which is the pre-run ref.
+            echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           fi
+
+      # opusdns-mcp embeds src/openapi.yaml as a file rather than consuming the
+      # npm package, so it needs a nudge to regenerate. Dispatching from here
+      # rather than from opusdns-api means main is already updated when it
+      # fetches, and that only real changes fire (the version-stamp dance above
+      # filters out the generation timestamp).
+      - name: Notify opusdns-mcp of the new spec
+        if: steps.commit.outputs.changed == 'true'
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          token: ${{ secrets.MCP_SPEC_DISPATCH_TOKEN }}
+          repository: OpusDNS/opusdns-mcp
+          event-type: openapi_spec_update
+          client-payload: '{"ref": "${{ steps.commit.outputs.sha }}"}'

--- a/.github/workflows/generate-ts-types.yaml
+++ b/.github/workflows/generate-ts-types.yaml
@@ -94,7 +94,9 @@ jobs:
         if: steps.commit.outputs.changed == 'true'
         uses: peter-evans/repository-dispatch@v4
         with:
-          token: ${{ secrets.MCP_SPEC_DISPATCH_TOKEN }}
+          # Scoped to opusdns-mcp only. Same token and same secret name that
+          # opusdns-mcp itself uses to open the resulting PR.
+          token: ${{ secrets.GH_PAT_OPENAPI_OPUSDNS_MCP }}
           repository: OpusDNS/opusdns-mcp
           event-type: openapi_spec_update
           client-payload: '{"ref": "${{ steps.commit.outputs.sha }}"}'


### PR DESCRIPTION
## Why

`opusdns-mcp` embeds `src/openapi.yaml` **as a file** (`internal/gen/opusdns.openapi.json`, parsed into its operation catalog at runtime) rather than consuming `@opusdns/api`. Nothing told it when the spec moved, so its copy had drifted six weeks — `2026-06-22` against `2026-08-04`, missing 12 paths and 13 operations.

This closes the fan-out. `opusdns-api` already dispatches `openapi_spec_update` here and to `api-spec-internal`; `opusdns-mcp` was the one consumer left out.

## What

After a successful commit + publish, dispatch `openapi_spec_update` at `OpusDNS/opusdns-mcp`. Its new `Sync OpenAPI Spec` workflow (OpusDNS/opusdns-mcp#26) refreshes the embedded file and opens a PR for review — it does not push to `main`, because a spec bump can silently change which of its operations require a human confirmation.

**Why dispatch from here rather than from `opusdns-api`**, alongside the existing two:

- `opusdns-mcp` fetches `src/openapi.yaml` from this repo's `main`. Dispatching after our push means `main` is already updated when it fetches — no race.
- It only fires on real changes. `info.version` is a generation timestamp that moves on every `opusdns-api` build; the version-stamp comparison in this workflow already filters that out, so gating on it avoids a stream of no-op PRs.

The `Commit & Push Changes` step gains an `id` and two outputs: `changed` to gate the dispatch, and `sha`, since `github.sha` is the pre-run ref and would misattribute the change in the downstream PR body.

Uses `peter-evans/repository-dispatch@v4`, as `tld-specifications`' `notify-api-spec.yaml` already does.

## Before merging: one secret is needed

`GH_PAT_OPENAPI_OPUSDNS_MCP` — **one** fine-grained PAT, resource owner OpusDNS, repository access **`opusdns-mcp` only**, permissions **Contents: write** + **Pull requests: write**. The same token goes into `opusdns-mcp` under the same name (OpusDNS/opusdns-mcp#26), where it opens the resulting PR; `repository_dispatch` from here only needs Contents, the Pull requests bit is for that side. Note `opusdns-mcp` is private, so org PAT-approval policy may need to allow it.

The dispatch step is the last in the job and gated on `changed == 'true'`, so a missing or under-scoped token cannot affect spec generation, the commit, or the npm publish — it fails after all of that, visibly.
