### PR TITLE
docs: sub-zone delegation guide + changelog entry

### DIFF
--- a/scalar/content/changelog.md
+++ b/scalar/content/changelog.md
@@ -4,7 +4,25 @@ Track notable updates to the OpusDNS API and developer documentation here.
 
 ## 2026
 
-### 17 July 2026
+### 04 August 2026
+
+- Added **sub-zone delegation**: NS records below the zone apex are now
+  fully supported on every zone endpoint — include them when creating a zone,
+  or manage them with the RRset and record PATCH endpoints like any other
+  record type. OpusDNS nameservers serve the delegation as a standard DNS
+  referral. Delegations from DNSSEC-signed zones are insecure delegations
+  (child DS records are not supported). See
+  [Delegate a subdomain](/products/dns/subzone-delegation).
+
+- Changed **writes targeting system-managed records to return errors instead
+  of silently doing nothing**. Previously, a `PUT`/`PATCH` that tried to
+  modify or remove the zone apex NS, SOA, DNSKEY, or DS records could return
+  `204 No Content` while the request had no effect. These now return
+  `409 Conflict` with a `protected_reason`. Zone responses also report
+  `protected: true` consistently for every system-managed RRset. If your
+  integration echoes a full zone read back into a write, filter out RRsets
+  with `protected: true` first — see
+  [Protected records](/products/dns/zone-object#protected-records).
 
 - Added **independent billing for suborganizations**: create a suborganization
   with `billing_mode: "independent"` and it gets its own wallet, invoices, and

--- a/scalar/content/dns/manage-records.md
+++ b/scalar/content/dns/manage-records.md
@@ -263,6 +263,10 @@ Certain records are system-managed and cannot be modified:
 - Records created by **email forwarding** or **domain forwarding** are
   managed through their respective APIs.
 
+NS records **below** the apex are not protected — they delegate a subdomain to
+other nameservers and are managed like any other record type. See
+[Delegate a subdomain](/products/dns/subzone-delegation).
+
 Attempting to modify a protected record returns an error. See
 [the zone object](/products/dns/zone-object#protected-records) for the full
 list of protection reasons.

--- a/scalar/content/dns/subzone-delegation.md
+++ b/scalar/content/dns/subzone-delegation.md
@@ -1,0 +1,94 @@
+# Delegate a subdomain
+
+Sub-zone delegation hands authority for a subdomain to a different set of
+nameservers, while the parent zone stays on OpusDNS. This is done with **NS
+records below the zone apex** — for example, delegating `internal.example.com`
+to your own infrastructure, or `shop.example.com` to another provider.
+
+Delegation NS RRsets are ordinary records: create them at zone creation or with
+any of the [record management endpoints](/products/dns/manage-records), and
+remove them the same way. This is different from changing the nameservers of
+the **whole domain** — for that, update the
+[domain's nameservers](/products/domains/nameservers) instead. NS records *at* the zone apex are
+system-managed by OpusDNS and cannot be modified through the zone endpoints.
+
+## Delegate a subdomain
+
+Add an NS RRset at the subdomain you want to delegate:
+
+```bash
+curl "$OPUSDNS_API_BASE/v1/dns/example.com/rrsets" \
+  --request PATCH \
+  --header "X-Api-Key: $OPUSDNS_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "ops": [
+      {
+        "op": "upsert",
+        "rrset": {
+          "name": "internal.example.com.",
+          "type": "NS",
+          "ttl": 3600,
+          "records": [
+            { "rdata": "ns1.other-provider.net." },
+            { "rdata": "ns2.other-provider.net." }
+          ]
+        }
+      }
+    ]
+  }'
+```
+
+From that moment, OpusDNS nameservers answer queries for
+`internal.example.com` (and every name below it) with a **referral** to
+`ns1.other-provider.net.` and `ns2.other-provider.net.` — those nameservers
+are now authoritative for the delegated subtree.
+
+You can also include delegation NS RRsets directly in the `rrsets` array when
+[creating a zone](/products/dns/manage-zones).
+
+## Remove a delegation
+
+Remove the NS RRset and the parent zone becomes authoritative for the subtree
+again:
+
+```bash
+curl "$OPUSDNS_API_BASE/v1/dns/example.com/rrsets" \
+  --request PATCH \
+  --header "X-Api-Key: $OPUSDNS_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "ops": [
+      {
+        "op": "remove",
+        "rrset": {
+          "name": "internal.example.com.",
+          "type": "NS",
+          "ttl": 3600,
+          "records": []
+        }
+      }
+    ]
+  }'
+```
+
+Individual nameservers can be added or removed one at a time with the
+record-level endpoint (`PATCH /v1/dns/{zone_name}/records`), like any other
+record type.
+
+## What to know before delegating
+
+- **Records below a delegation point stop resolving publicly.** Once
+  `internal.example.com` is delegated, any records the parent zone holds at or
+  below that name — including [domain forwards](/products/dns/domain-forwarding),
+  [email forwards](/products/dns/email-forwarding), and parking — are no longer
+  served; the delegated nameservers are authoritative for that subtree. The
+  records remain stored in the zone and resolve again if the delegation is
+  removed.
+- **Delegations from DNSSEC-signed zones are insecure delegations.** Child DS
+  records are not supported, so the delegated subtree is not covered by the
+  parent's chain of trust. The delegation itself works — resolvers simply treat
+  the subtree as unsigned. DS RRsets in zone payloads are rejected.
+- **The delegated nameservers must be set up separately.** OpusDNS publishes
+  the referral; serving the actual records for the subtree is up to the
+  nameservers you delegate to.

--- a/scalar/scalar.config.json
+++ b/scalar/scalar.config.json
@@ -429,6 +429,13 @@
                     "filepath": "content/dns/manage-records.md",
                     "showInSidebar": true
                   },
+                  "/subzone-delegation": {
+                    "type": "page",
+                    "title": "Delegate a subdomain",
+                    "icon": "line/arrow-right",
+                    "filepath": "content/dns/subzone-delegation.md",
+                    "showInSidebar": true
+                  },
                   "/dnssec": {
                     "type": "page",
                     "title": "DNSSEC",


### PR DESCRIPTION
New "Delegate a subdomain" guide page (sidebar-registered), changelog entry for 04 Aug covering the delegation feature and the system-managed-write error behavior, and a protected-records cross-link.

Documents the feature shipped in opusdns-api #5060 / #5066.

https://claude.ai/code/session_01RqcCeuxu3HoamRZyDuiWCY