### PR TITLE
docs: changelog entry for .pl, .gg, .je, .brussels, .vlaanderen launches

### DIFF
--- a/scalar/content/changelog.md
+++ b/scalar/content/changelog.md
@@ -4,6 +4,17 @@ Track notable updates to the OpusDNS API and developer documentation here.
 
 ## 2026
 
+### 10 August 2026
+
+- Onboarded **`.pl`** (Poland) together with its second-level extensions
+  `.com.pl`, `.net.pl`, and `.org.pl`, plus **`.gg`** (Guernsey) and
+  **`.je`** (Jersey). Published their
+  [TLD Knowledge Base](/tld-knowledge-base) pages.
+
+- Onboarded the Belgian geographic TLDs **`.brussels`** and
+  **`.vlaanderen`**. Published their
+  [TLD Knowledge Base](/tld-knowledge-base) pages.
+
 ### 04 August 2026
 
 - Added **sub-zone delegation**: NS records below the zone apex are now

--- a/scalar/content/changelog.md
+++ b/scalar/content/changelog.md
@@ -7,8 +7,9 @@ Track notable updates to the OpusDNS API and developer documentation here.
 ### 10 August 2026
 
 - Onboarded **`.pl`** (Poland) together with its second-level extensions
-  `.com.pl`, `.net.pl`, and `.org.pl`, plus **`.gg`** (Guernsey) and
-  **`.je`** (Jersey). Published their
+  `.com.pl`, `.net.pl`, and `.org.pl`; **`.gg`** (Guernsey) together with
+  `.co.gg`, `.net.gg`, and `.org.gg`; and **`.je`** (Jersey) together with
+  `.co.je`, `.net.je`, and `.org.je`. Published their
   [TLD Knowledge Base](/tld-knowledge-base) pages.
 
 - Onboarded the Belgian geographic TLDs **`.brussels`** and


### PR DESCRIPTION
Adds the 10 August 2026 changelog section for today's TLD launches (prod registry rows created 2026-08-10). KB pages already merged in #112/#113.

https://claude.ai/code/session_019fCuaQwgsuxWaMDjeJ4znU