### PR TITLE
docs: changelog entry + KB pages for .wales and .cymru launch

### DIFF
--- a/scalar/content/changelog.md
+++ b/scalar/content/changelog.md
@@ -4,6 +4,12 @@ Track notable updates to the OpusDNS API and developer documentation here.
 
 ## 2026
 
+### 11 August 2026
+
+- Onboarded the Welsh geographic TLDs **`.wales`** and **`.cymru`**
+  (operated by Nominet). Published their
+  [TLD Knowledge Base](/tld-knowledge-base) pages.
+
 ### 10 August 2026
 
 - Onboarded **`.pl`** (Poland) together with its second-level extensions

--- a/scalar/content/tld-knowledge-base/gtlds/cymru.md
+++ b/scalar/content/tld-knowledge-base/gtlds/cymru.md
@@ -1,0 +1,112 @@
+# 🌐 .cymru — Nominet UK
+
+> The **.cymru** is a generic top-level domain (gTLD) operated by Nominet UK. This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
+
+## General Information
+
+| Property | Value |
+| --- | --- |
+| TLD Type | gTLD |
+| Registry | Nominet UK |
+| Registry Country | United Kingdom |
+| Registry Website | [www.nominet.uk](https://www.nominet.uk) |
+| Provisioning Protocol | EPP |
+| Second-Level Registration | ✅ Yes |
+| Accreditation Required | ✅ Yes |
+
+## Domain Lifecycle
+
+| Property | Value |
+| --- | --- |
+| Registration Period | 1–10 years |
+| Renewal Period | 1–10 years |
+| Transfer Renewal Period | 1 year |
+| Deletion Policy | Immediate, At expiration |
+| Auto-Renew Enabled | ✅ Yes |
+| Auto-Renewal Before Expiry | 7 days before expiration |
+| Sync After Operations | registration, renewal, transfer |
+
+**Grace periods**
+
+| Period | Duration |
+| --- | --- |
+| Add Grace Period | 5 days |
+| Standard Grace Period | 45 days |
+| Redemption Period | 30 days |
+| Pending Restore | 7 days |
+| Pending Delete | 5 days |
+
+## Launch Phases & Availability
+
+| Property | Value |
+| --- | --- |
+| General Availability | ✅ TLD is live |
+| TMCH / Trademark Claims | ❌ No |
+
+## Domain Characteristics
+
+| Property | Value |
+| --- | --- |
+| Domain Length | 1–63 characters |
+| IDN Support | ✅ Yes (1 tables) |
+| Premium Domains | ❌ No |
+| Reserved Domains | ❌ No |
+| Registry Lock | ✅ Yes |
+
+## Contacts & Roles
+
+| Property | Value |
+| --- | --- |
+| Required Contacts | Domain Owner |
+| Supported Roles | Domain Owner, Administrator, Technical Contact, Billing Contact |
+| Thick WHOIS | ✅ Yes |
+| Privacy Proxy Allowed | ❌ No |
+| Contacts Transferable | ❌ No |
+| Allowed Postal Types | Local, International |
+| AuthInfo Required | ❌ No |
+
+## Nameservers & DNS
+
+| Property | Value |
+| --- | --- |
+| Nameserver Count | 0–10 |
+| Host Objects Allowed | ✅ Yes |
+| Registry Nameserver Check | ❌ No |
+| DNSSEC Allowed | ✅ Yes |
+| DNSSEC Required | ❌ No |
+| DNSSEC Mode | DS |
+| CZDS (Zone Download) | ❌ No |
+
+## Transfer Policy
+
+| Property | Value |
+| --- | --- |
+| Transfer Lock Enabled | ✅ Yes (0 days after registration; 0 days after transfer) |
+| Transfer Duration | 0 days |
+| Transfer Extends Domain | ❌ No |
+| Transfer via AuthInfo | ❌ No |
+| Confirmation Required | ✅ Yes (registrar) |
+
+## WHOIS & RDAP
+
+| Property | Value |
+| --- | --- |
+| WHOIS Server | `whois.nic.cymru` |
+| RDAP Server | [rdap.nominet.uk/cymru](https://rdap.nominet.uk/cymru/) |
+
+## Dispute Resolution
+
+| Property | Value |
+| --- | --- |
+| Dispute Resolution Available | ✅ Yes |
+| Procedure | UDRP |
+| Reference | [www.icann.org/resources/pages/help/dndr/udrp-en](https://www.icann.org/resources/pages/help/dndr/udrp-en) |
+| UDRP Support | ✅ Yes |
+| URS Support | ✅ Yes |
+
+## Implementation Notes
+
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/content/tld-knowledge-base/gtlds/wales.md
+++ b/scalar/content/tld-knowledge-base/gtlds/wales.md
@@ -1,0 +1,112 @@
+# 🌐 .wales — Nominet UK
+
+> The **.wales** is a generic top-level domain (gTLD) operated by Nominet UK. This article documents the technical, operational, and contractual requirements for the TLD, along with special considerations for registry, registrar, and domain management.
+
+## General Information
+
+| Property | Value |
+| --- | --- |
+| TLD Type | gTLD |
+| Registry | Nominet UK |
+| Registry Country | United Kingdom |
+| Registry Website | [www.nominet.uk](https://www.nominet.uk) |
+| Provisioning Protocol | EPP |
+| Second-Level Registration | ✅ Yes |
+| Accreditation Required | ✅ Yes |
+
+## Domain Lifecycle
+
+| Property | Value |
+| --- | --- |
+| Registration Period | 1–10 years |
+| Renewal Period | 1–10 years |
+| Transfer Renewal Period | 1 year |
+| Deletion Policy | Immediate, At expiration |
+| Auto-Renew Enabled | ✅ Yes |
+| Auto-Renewal Before Expiry | 7 days before expiration |
+| Sync After Operations | registration, renewal, transfer |
+
+**Grace periods**
+
+| Period | Duration |
+| --- | --- |
+| Add Grace Period | 5 days |
+| Standard Grace Period | 45 days |
+| Redemption Period | 30 days |
+| Pending Restore | 7 days |
+| Pending Delete | 5 days |
+
+## Launch Phases & Availability
+
+| Property | Value |
+| --- | --- |
+| General Availability | ✅ TLD is live |
+| TMCH / Trademark Claims | ❌ No |
+
+## Domain Characteristics
+
+| Property | Value |
+| --- | --- |
+| Domain Length | 1–63 characters |
+| IDN Support | ✅ Yes (1 tables) |
+| Premium Domains | ❌ No |
+| Reserved Domains | ❌ No |
+| Registry Lock | ✅ Yes |
+
+## Contacts & Roles
+
+| Property | Value |
+| --- | --- |
+| Required Contacts | Domain Owner |
+| Supported Roles | Domain Owner, Administrator, Technical Contact, Billing Contact |
+| Thick WHOIS | ✅ Yes |
+| Privacy Proxy Allowed | ❌ No |
+| Contacts Transferable | ❌ No |
+| Allowed Postal Types | Local, International |
+| AuthInfo Required | ❌ No |
+
+## Nameservers & DNS
+
+| Property | Value |
+| --- | --- |
+| Nameserver Count | 0–10 |
+| Host Objects Allowed | ✅ Yes |
+| Registry Nameserver Check | ❌ No |
+| DNSSEC Allowed | ✅ Yes |
+| DNSSEC Required | ❌ No |
+| DNSSEC Mode | DS |
+| CZDS (Zone Download) | ❌ No |
+
+## Transfer Policy
+
+| Property | Value |
+| --- | --- |
+| Transfer Lock Enabled | ✅ Yes (0 days after registration; 0 days after transfer) |
+| Transfer Duration | 0 days |
+| Transfer Extends Domain | ❌ No |
+| Transfer via AuthInfo | ❌ No |
+| Confirmation Required | ✅ Yes (registrar) |
+
+## WHOIS & RDAP
+
+| Property | Value |
+| --- | --- |
+| WHOIS Server | `whois.nic.wales` |
+| RDAP Server | [rdap.nominet.uk/wales](https://rdap.nominet.uk/wales/) |
+
+## Dispute Resolution
+
+| Property | Value |
+| --- | --- |
+| Dispute Resolution Available | ✅ Yes |
+| Procedure | UDRP |
+| Reference | [www.icann.org/resources/pages/help/dndr/udrp-en](https://www.icann.org/resources/pages/help/dndr/udrp-en) |
+| UDRP Support | ✅ Yes |
+| URS Support | ✅ Yes |
+
+## Implementation Notes
+
+- Ensure complete TLS/SSL configuration for every registry environment.
+- Enable DNSSEC wherever the registry supports it.
+- Make sure AuthInfo/transfer secrets meet the registry's length and format requirements.
+- Review the registry's supported domain statuses and dispute-resolution policies before launch.

--- a/scalar/scalar.config.json
+++ b/scalar/scalar.config.json
@@ -1648,6 +1648,12 @@
                 "filepath": "content/tld-knowledge-base/gtlds/cruises.md",
                 "showInSidebar": true
               },
+              "/cymru": {
+                "type": "page",
+                "title": "🌐 .cymru",
+                "filepath": "content/tld-knowledge-base/gtlds/cymru.md",
+                "showInSidebar": true
+              },
               "/cyou": {
                 "type": "page",
                 "title": "🌐 .cyou",
@@ -3548,6 +3554,12 @@
                 "type": "page",
                 "title": "🌐 .voyage",
                 "filepath": "content/tld-knowledge-base/gtlds/voyage.md",
+                "showInSidebar": true
+              },
+              "/wales": {
+                "type": "page",
+                "title": "🌐 .wales",
+                "filepath": "content/tld-knowledge-base/gtlds/wales.md",
                 "showInSidebar": true
               },
               "/watch": {

--- a/scripts/tld_knowledge_base/excluded_tlds.txt
+++ b/scripts/tld_knowledge_base/excluded_tlds.txt
@@ -7,7 +7,5 @@ dk
 mx
 pt
 ee
-wales
-cymru
 se
 nu


### PR DESCRIPTION
- 11 Aug changelog entry: `.wales` + `.cymru` live in production ([announcement](https://opusdns.slack.com/archives/C07QVDEA3A7/p1786475839564109))
- KB pages generated from compiled TLD specs; removed both from `excluded_tlds.txt`

https://claude.ai/code/session_01EqwWA6oABtzLJhXKMbdmQb