### PR TITLE
docs: postal code validation and registry error detail

### DIFF
--- a/scalar/content/changelog.md
+++ b/scalar/content/changelog.md
@@ -4,6 +4,33 @@ Track notable updates to the OpusDNS API and developer documentation here.
 
 ## 2026
 
+### 14 August 2026
+
+- Added **postal code validation on contacts**: `postal_code` is validated
+  against the country's published format for an initial set of 16 countries
+  (`AT`, `BE`, `CA`, `CH`, `CZ`, `DE`, `DK`, `ES`, `FR`, `GB`, `IT`, `LU`,
+  `NL`, `NO`, `SE`, `US`). Contacts in every other country are unaffected. An
+  invalid postal code returns a `422` request-validation error whose error
+  `type` is `invalid_postal_code`, locating the `postal_code` field. A postal
+  code containing non-ASCII characters is rejected for every country, because
+  it cannot be transmitted to a registry. See
+  [Postal codes](/products/contacts/postal-codes).
+
+- Changed **postal codes to be stored in a canonical form**: Dutch postal codes
+  are stored in the official national notation (`1234 AB` — both `1234AB` and
+  `1234 ab` are accepted), cross-border country prefixes are stripped
+  (`D-26133` → `26133` for a `DE` contact), and US ZIP+4 is normalized to the
+  hyphenated form (`12345 6789` → `12345-6789`). Existing Dutch contact data
+  was migrated to the canonical form. See
+  [What gets stored](/products/contacts/postal-codes#what-gets-stored).
+
+- Added **the registry's own field-level validation messages** to registry
+  errors. Where a registry reports which field it refused, an
+  `ERROR_REGISTRY_POLICY` on a domain or contact operation now carries that text
+  in `detail` after the generic result code, instead of the result code text
+  alone. For a `.nl` postcode rejected by SIDN, `detail` now ends with
+  `Contact address group: A postcode has to be four numbers and two letters.`
+
 ### 11 August 2026
 
 - Onboarded the Welsh geographic TLDs

--- a/scalar/content/contacts/postal-codes.md
+++ b/scalar/content/contacts/postal-codes.md
@@ -1,0 +1,125 @@
+# Postal codes
+
+The `postal_code` of a contact is validated against the country's published
+postal format and stored in that country's canonical notation. Validation runs
+when the contact is written — with `POST /v1/contacts`, or with the
+`contact_create` and `contact_create_bulk`
+[job commands](/automation/jobs/dns-commands) — so a postal code a registry
+would refuse fails immediately, with the field named, instead of failing at the
+registry after the contact has been stored.
+
+## Validated countries
+
+An invalid postal code is refused for these countries:
+
+| Country | Example format |
+| --- | --- |
+| `AT` Austria | `1010` |
+| `BE` Belgium | `4000` |
+| `CA` Canada | `H3Z 2Y7` |
+| `CH` Switzerland | `2544` |
+| `CZ` Czechia | `100 00` |
+| `DE` Germany | `26133` |
+| `DK` Denmark | `8660` |
+| `ES` Spain | `28039` |
+| `FR` France | `33380` |
+| `GB` United Kingdom | `EC1Y 8SY` |
+| `IT` Italy | `00144` |
+| `LU` Luxembourg | `4750` |
+| `NL` Netherlands | `1234 AB` |
+| `NO` Norway | `0025` |
+| `SE` Sweden | `11455` |
+| `US` United States | `95014` |
+
+Contacts in any other country accept whatever you submit. One rule applies
+everywhere: a postal code containing non-ASCII characters is rejected for every
+country, because it cannot be transmitted to a registry.
+
+## Rejected postal codes
+
+An invalid postal code returns `422` with a `request-validation-failed` problem
+that names the field, so it can be mapped back to a form field:
+
+```json
+{
+  "type": "request-validation-failed",
+  "title": "Request validation error.",
+  "status": 422,
+  "errors": [
+    {
+      "type": "invalid_postal_code",
+      "loc": ["body", "postal_code"],
+      "msg": "'93053' is not a valid postal code for country 'NL', expected a format like '1234 AB'",
+      "input": "93053",
+      "ctx": {
+        "message": "'93053' is not a valid postal code for country 'NL', expected a format like '1234 AB'"
+      }
+    }
+  ]
+}
+```
+
+`type` is `invalid_postal_code` — a stable key for this rejection — and `msg`
+quotes the value you submitted together with an example of the expected format.
+
+## What gets stored
+
+Postal codes are canonicalized on write, so the stored value can differ from
+what you submitted:
+
+| Submitted | Country | Stored |
+| --- | --- | --- |
+| `1234AB` | `NL` | `1234 AB` |
+| `1234 ab` | `NL` | `1234 AB` |
+| `D-26133` | `DE` | `26133` |
+| `NL-1234AB` | `NL` | `1234 AB` |
+| `12345 6789` | `US` | `12345-6789` |
+| `100 00` | `CZ` | `100 00` |
+
+- Dutch postal codes are stored in the official national notation — four
+  digits, a space, two upper-case letters. Both `1234AB` and `1234 ab` are
+  accepted.
+- The cross-border country prefix (`D-`, `NL-`, `F-`, …) is not part of a postal
+  code and is stripped. It is only stripped when it matches the contact's own
+  country: `F-26133` on a `DE` contact keeps the `F-` and is rejected as an
+  invalid German postal code.
+- US ZIP+4 is stored in the hyphenated form.
+- Where a space is part of the national format, as in `CZ` and `GB`, it is kept.
+
+## Registry-specific formats
+
+Some registries require a different form than the national notation — SIDN, for
+example, requires a `.nl` postal code without the space. OpusDNS applies those
+rules when it builds the registry request. Store and submit the national format
+and never pre-format a postal code for a registry; the value you read back from
+the API is always the canonical national form.
+
+## Imported contacts
+
+Contacts mirrored from another registrar or registry — domain import,
+transfer-in, and registrar sync — are canonicalized where possible but are
+never rejected for their postal code format, so an off-format value held at the
+losing registrar cannot fail an import.
+
+## Registry rejections
+
+A registry can still refuse an address for its own reasons. Where the registry
+reports which field was at fault, that text is included in the `detail` of the
+resulting problem, after the generic result code:
+
+```
+2308: Validation of the transaction failed. Contact address group: A postcode has to be four numbers and two letters.
+```
+
+## Errors
+
+| Code | Status | Meaning |
+| --- | --- | --- |
+| `invalid_postal_code` | 422 | The postal code is not valid for the contact's country. Returned as an error `type` inside a `request-validation-failed` problem, with `loc` naming `postal_code`. |
+| `ERROR_REGISTRY_POLICY` | 422 | The registry rejected the request. `detail` carries the registry's field-level message where the registry provides one. |
+
+## Related API Reference
+
+- [`POST /v1/contacts`](/api-reference#tag/contact/POST/v1/contacts)
+- [`GET /v1/contacts`](/api-reference#tag/contact/GET/v1/contacts)
+- [`GET /v1/contacts/{contact_id}`](/api-reference#tag/contact/GET/v1/contacts/{contact_id})

--- a/scalar/scalar.config.json
+++ b/scalar/scalar.config.json
@@ -342,12 +342,12 @@
               },
               "/contacts": {
                 "type": "group",
-                "title": "Contact Verification",
-                "icon": "phosphor/regular/shield-check",
+                "title": "Contacts",
+                "icon": "line/interface-users-multiple",
                 "children": {
                   "/verification": {
                     "type": "page",
-                    "title": "Overview",
+                    "title": "Contact verification",
                     "icon": "phosphor/regular/shield-check",
                     "filepath": "content/contacts/overview.md",
                     "showInSidebar": true
@@ -364,6 +364,13 @@
                     "title": "Initialize verification",
                     "icon": "line/interface-add",
                     "filepath": "content/contacts/initialize-verification.md",
+                    "showInSidebar": true
+                  },
+                  "/postal-codes": {
+                    "type": "page",
+                    "title": "Postal codes",
+                    "icon": "line/interface-content-file",
+                    "filepath": "content/contacts/postal-codes.md",
                     "showInSidebar": true
                   }
                 }


### PR DESCRIPTION
Changelog entry for 14 August 2026 covering the 16-country postal code validation, canonical storage, and registry field-level messages in `detail`.

New `Postal codes` page under Contacts (registered in `scalar.config.json`) with the validated-country list, the `invalid_postal_code` 422 shape, the canonicalization table, and the import/registry-format notes. The contacts group is renamed `Contacts` since it is no longer verification-only.

Prose only — no generated spec files touched. `npm --prefix scalar run check` passes.

https://claude.ai/code/session_01XG1R8F7PBDh4MH9s7CkN87