### PR TITLE
introduce read_only flag

### DIFF
--- a/scalar/content/changelog.md
+++ b/scalar/content/changelog.md
@@ -4,6 +4,18 @@ Track notable updates to the OpusDNS API and developer documentation here.
 
 ## 2026
 
+### 18 August 2026
+
+- Added **a `read_only` flag to the domain object**: a domain marked read-only
+  is listed in your portfolio but cannot be managed — updates, renewals, and
+  deletions are rejected. OpusDNS sets and removes the flag; it cannot be
+  changed through the API. It is used for domains imported ahead of a
+  migration, domains locked for legal reasons, and domains managed at an
+  external registrar. The flag is included in every domain response and
+  `GET /v1/domains` accepts a `read_only` query parameter to filter by it. See
+  [The domain object](/products/domains/domain-object) and
+  [Read-only domains](/products/domains/manage#read-only-domains).
+
 ### 14 August 2026
 
 - Added **postal code validation on contacts**: `postal_code` is validated

--- a/scalar/content/domains/domain-object.md
+++ b/scalar/content/domains/domain-object.md
@@ -17,6 +17,7 @@ returned by all domain endpoints — registration, transfer, update, and retriev
   "renewal_mode": "renew",
   "transfer_lock": false,
   "is_premium": false,
+  "read_only": false,
   "registered_on": "2026-01-15T10:30:00Z",
   "expires_on": "2027-01-15T10:30:00Z",
   "created_on": "2026-01-15T10:30:00Z",
@@ -61,6 +62,7 @@ returned by all domain endpoints — registration, transfer, update, and retriev
 | `renewal_mode` | `string` | How the domain handles expiry. `"renew"` — the domain auto-renews before expiration. `"expire"` — the domain is allowed to expire. |
 | `transfer_lock` | `boolean` | Whether the domain is locked to prevent outbound transfers. When `true`, the domain cannot be transferred to another registrar. |
 | `is_premium` | `boolean` | Whether this is a premium domain with non-standard pricing. See [Premium domains](/products/domains/premium). |
+| `read_only` | `boolean` | Whether the domain is read-only in OpusDNS. When `true`, the domain is listed in your portfolio but cannot be managed — for example while it awaits a migration, is locked for legal reasons, or is managed at an external registrar. The flag is set and removed by OpusDNS; it cannot be changed through the API. |
 
 ### Dates
 

--- a/scalar/content/domains/manage-domain.md
+++ b/scalar/content/domains/manage-domain.md
@@ -128,6 +128,16 @@ you must remove them before making other changes:
 - `pendingDelete`
 - `redemptionPeriod`
 
+### Read-only domains
+
+A domain with `read_only: true` cannot be managed at all — updates, renewals,
+and deletions are rejected. OpusDNS sets this flag on domains that are listed
+in your portfolio but not manageable, for example while they await a
+migration, are locked for legal reasons, or are managed at an external
+registrar. The flag is removed by OpusDNS when management becomes available;
+it cannot be changed through the API. To find affected domains, filter with
+the `read_only` query parameter on `GET /v1/domains`.
+
 ## Rotate auth code
 
 Generate a new authorization code for a domain:

--- a/scalar/content/domains/register-domain.md
+++ b/scalar/content/domains/register-domain.md
@@ -201,6 +201,7 @@ The registration returns a `DomainResponse` with the full domain details:
   "renewal_mode": "renew",
   "transfer_lock": false,
   "is_premium": false,
+  "read_only": false,
   "registered_on": "2026-05-04T10:30:00Z",
   "expires_on": "2027-05-04T10:30:00Z",
   "nameservers": [


### PR DESCRIPTION
### Background

The upstream `opusdns-api` PR introduces a `read_only` flag on the domain model as the
first step of the planned .NL portfolio-migration process: domains bulk-imported ahead
of a migration are flagged read-only so they appear in the customer's portfolio before
management is switched over. The flag is deliberately generic — it equally covers
domains locked for legal reasons and domains managed at an external registrar that
should only be listed in a portfolio.

For customers this means:

- Every domain response now includes `read_only: boolean`.
- A domain with `read_only: true` is listed in the portfolio but cannot be managed —
  updates, renewals, and deletions are rejected.
- The flag is set and removed by OpusDNS; it cannot be changed through the API.
- `GET /v1/domains` accepts a `read_only` query parameter to filter by it.

This PR adds the matching customer documentation. The API reference itself needs no
change here — `src/openapi.yaml` syncs automatically once the upstream PR merges.

### Changes

- **`scalar/content/changelog.md`** — new entry (18 August 2026) announcing the flag,
  its semantics, and the new query filter, linking to the domain-object guide and the
  new "Read-only domains" section.
- **`scalar/content/domains/domain-object.md`** — `read_only` added to the example
  domain object and documented in the field table (meaning, use cases, OpusDNS-managed,
  not changeable via the API).
- **`scalar/content/domains/manage-domain.md`** — new "Read-only domains" subsection
  explaining that such domains cannot be managed, when OpusDNS applies/removes the
  flag, and how to find affected domains via the `read_only` filter.
- **`scalar/content/domains/register-domain.md`** — `read_only` added to the example
  registration response.

Field descriptions are aligned word-for-word with the API field description in
`opusdns-api`.

### Notes

- Should merge when the upstream `opusdns-api` PR ships, so guides, changelog, and the
  auto-synced API reference land together.
- The docs describe the final behavior; enforcement ships upstream in a follow-up, but
  no customer domain carries the flag until OpusDNS sets it.

🤖 Generated with [Claude Code]