### PR TITLE
docs: sandbox tz-aware datetime cutover completed [DEV-1561]

### DIFF
--- a/scalar/content/changelog.md
+++ b/scalar/content/changelog.md
@@ -6,6 +6,14 @@ Track notable updates to the OpusDNS API and developer documentation here.
 
 ### 18 August 2026
 
+- Changed **the sandbox environment to serve timezone-aware (RFC 3339) datetimes
+  by default**, on schedule per the announced staged cutover. Every datetime in
+  public `/v1` responses from sandbox now carries the explicit UTC designator
+  (trailing `Z`); the `X-Datetime-Format: rfc3339` header remains accepted there
+  and is now a no-op. Production follows on Monday, 2026-09-01. See
+  [Timezone-aware datetimes (RFC 3339)](/upcoming-changes/rfc3339-datetimes) for
+  migration guidance.
+
 - Added **a `read_only` flag to the domain object**: a domain marked read-only
   is listed in your portfolio but cannot be managed — updates, renewals, and
   deletions are rejected. OpusDNS sets and removes the flag; it cannot be

--- a/scalar/content/upcoming-changes/rfc3339-datetimes.md
+++ b/scalar/content/upcoming-changes/rfc3339-datetimes.md
@@ -4,6 +4,11 @@ The public `/v1` API is standardizing datetime fields on **RFC 3339** with an
 explicit UTC designator. You can opt in today with a request header, and the new
 format becomes the default on a staged schedule per environment.
 
+<scalar-callout type="info">
+<strong>Sandbox switched to the tz-aware default on 2026-08-18</strong>, as
+scheduled. Production follows on Monday, 2026-09-01.
+</scalar-callout>
+
 ## What is changing
 
 All datetimes the API returns represent UTC instants. Today most fields are
@@ -97,10 +102,13 @@ required. The header keeps working after cutover and simply becomes a no-op (it 
 always accepted and never causes an error). Adopt the header before your target date
 so the switch is a no-op for you.
 
-| Environment | Default cutover date |
-| ----------- | -------------------- |
-| Sandbox     | Monday, 2026-08-18   |
-| Production  | Monday, 2026-09-01   |
+| Environment | Default cutover date | Status    |
+| ----------- | -------------------- | --------- |
+| Sandbox     | Monday, 2026-08-18   | Completed |
+| Production  | Monday, 2026-09-01   | Upcoming  |
+
+Sandbox completed its cutover on schedule and serves tz-aware datetimes by default.
+Test your integration against sandbox now to be ready for the production date.
 
 ## Scope
 


### PR DESCRIPTION
Changelog note + upcoming-changes page update: sandbox serves RFC 3339 / tz-aware datetimes by default as of 2026-08-18 (announced schedule); production Sep 1 remains upcoming. Content-only (scalar/content), nothing generated touched.

https://claude.ai/code/session_014AAdhP9Z4whSJMm63t7eVq